### PR TITLE
Improve get meetups

### DIFF
--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { type Request, type Response } from 'express';
-import { ParsedQs } from 'qs';
+import { type ParsedQs } from 'qs';
 import { ArrayOverlap, ILike, In, type FindOptionsWhere } from 'typeorm';
 import { Meetup } from '../entity/Meetup';
 import { Ticket } from '../entity/Ticket';

--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -11,45 +11,89 @@ import { validateMeetup } from '../util/validator';
 
 dayjs.extend(utc);
 
-/**
- * This contains basic information about a meetup, mainly details necessary for
- * the homepage
- */
-export interface SimpleMeetupInfo {
+export interface MeetupInfo {
   id: number;
   name: string;
   date: string;
   location: {
-    city: string;
-    state: string;
-    country: string;
-  };
-  image_url: string;
-}
-
-/**
- * This contains all important information about a meetup
- */
-export interface FullMeetupInfo {
-  id: number;
-  name: string;
-  date: string;
-  location: {
-    full_address: string;
-    address_line_1: string;
-    address_line_2: string;
+    full_address?: string;
+    address_line_1?: string;
+    address_line_2?: string;
     city: string;
     state: string | null;
     country: string;
-    postal_code: string;
+    postal_code?: string;
   };
-  organizers: string[];
-  tickets: {
+  organizers?: string[];
+  tickets?: {
     total: number;
     available: number;
   };
   image_url: string;
 }
+
+enum MeetupInfoType {
+  Simple,
+  Detailed,
+}
+
+const mapMeetupInfo = async (
+  meetup: Meetup,
+  type: MeetupInfoType
+): Promise<MeetupInfo> => {
+  const meetupInfo: MeetupInfo = {
+    id: meetup.id,
+    name: meetup.name,
+    date: dayjs(meetup.date).utcOffset(meetup.utc_offset).format(),
+    location: {
+      city: meetup.city,
+      state: meetup.state,
+      country: meetup.country,
+    },
+    image_url: meetup.image_url,
+  };
+
+  if (type === MeetupInfoType.Detailed) {
+    // Build full address
+    const addressComponents: string[] = [];
+    if (meetup.address_line_1 !== '')
+      addressComponents.push(meetup.address_line_1);
+    if (meetup.address_line_2 !== '')
+      addressComponents.push(meetup.address_line_2);
+    if (meetup.city !== '') addressComponents.push(meetup.city);
+    if (meetup.state !== '') addressComponents.push(meetup.state);
+    if (meetup.country !== '') addressComponents.push(meetup.country);
+    if (meetup.postal_code !== '') addressComponents.push(meetup.postal_code);
+    meetupInfo.location.full_address = addressComponents.join(', ');
+    meetupInfo.location.address_line_1 = meetup.address_line_1;
+    meetupInfo.location.address_line_2 = meetup.address_line_2;
+    meetupInfo.location.postal_code = meetup.postal_code;
+
+    // Get organizer names
+    const organizers = await User.find({
+      select: ['nick_name'],
+      where: {
+        id: In(meetup.organizer_ids),
+      },
+    });
+
+    meetupInfo.organizers = organizers.map((organizer) => organizer.nick_name);
+
+    // Get ticket details
+    const ticketCount = await Ticket.count({
+      where: {
+        meetup_id: meetup.id,
+      },
+    });
+
+    meetupInfo.tickets = {
+      total: meetup.capacity,
+      available: meetup.capacity - ticketCount,
+    };
+  }
+
+  return meetupInfo;
+};
 
 export const getAllMeetups = async (
   req: Request,
@@ -76,30 +120,19 @@ export const getAllMeetups = async (
   // TODO(jan): Add additional filters and sorting options
 
   // Query
-  const meetups: SimpleMeetupInfo[] = (
+  const meetups: Array<Promise<MeetupInfo>> = (
     await Meetup.find({
       where: findOptionsWhere,
       order: {
         date: 'ASC',
       },
     })
-  ).map((meetup: Meetup): SimpleMeetupInfo => {
-    const simplifiedMeetupInfo: SimpleMeetupInfo = {
-      id: meetup.id,
-      name: meetup.name,
-      date: dayjs(meetup.date).utcOffset(meetup.utc_offset).format(),
-      location: {
-        city: meetup.city,
-        state: meetup.state,
-        country: meetup.country,
-      },
-      image_url: meetup.image_url,
-    };
-
-    return simplifiedMeetupInfo;
+  ).map(async (meetup: Meetup): Promise<MeetupInfo> => {
+    const meetupInfo = await mapMeetupInfo(meetup, MeetupInfoType.Simple);
+    return meetupInfo;
   });
 
-  return res.json(meetups);
+  return res.json(await Promise.all(meetups));
 };
 
 export const getMeetup = async (
@@ -116,58 +149,7 @@ export const getMeetup = async (
     return res.status(404).json({ message: 'Invalid meetup ID.' });
   }
 
-  const meetupInfo: FullMeetupInfo = {
-    id: meetup.id,
-    name: meetup.name,
-    date: dayjs(meetup.date).utcOffset(meetup.utc_offset).format(),
-    location: {
-      full_address: '',
-      address_line_1: meetup.address_line_1,
-      address_line_2: meetup.address_line_2,
-      city: meetup.city,
-      state: meetup.state,
-      country: meetup.country,
-      postal_code: meetup.postal_code,
-    },
-    organizers: [],
-    tickets: {
-      total: meetup.capacity,
-      available: 0,
-    },
-    image_url: meetup.image_url,
-  };
-
-  // Build full address
-  const addressComponents: string[] = [];
-  if (meetup.address_line_1 !== '')
-    addressComponents.push(meetup.address_line_1);
-  if (meetup.address_line_2 !== '')
-    addressComponents.push(meetup.address_line_2);
-  if (meetup.city !== '') addressComponents.push(meetup.city);
-  if (meetup.state !== '') addressComponents.push(meetup.state);
-  if (meetup.country !== '') addressComponents.push(meetup.country);
-  if (meetup.postal_code !== '') addressComponents.push(meetup.postal_code);
-
-  meetupInfo.location.full_address = addressComponents.join(', ');
-
-  // Get organizer names
-  const organizers = await User.find({
-    select: ['nick_name'],
-    where: {
-      id: In(meetup.organizer_ids),
-    },
-  });
-
-  meetupInfo.organizers = organizers.map((organizer) => organizer.nick_name);
-
-  // Calculate available tickets
-  const ticketCount = await Ticket.count({
-    where: {
-      meetup_id: meetup.id,
-    },
-  });
-
-  meetupInfo.tickets.available = meetupInfo.tickets.total - ticketCount;
+  const meetupInfo = await mapMeetupInfo(meetup, MeetupInfoType.Detailed);
 
   return res.json(meetupInfo);
 };

--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -1,9 +1,8 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { type Request, type Response } from 'express';
-import Joi from 'joi';
 import { ParsedQs } from 'qs';
-import { ArrayContains, ILike, In, type FindOptionsWhere } from 'typeorm';
+import { ArrayOverlap, ILike, In, type FindOptionsWhere } from 'typeorm';
 import { Meetup } from '../entity/Meetup';
 import { Ticket } from '../entity/Ticket';
 import { User } from '../entity/User';
@@ -100,16 +99,25 @@ const createMeetupsFilter = (query: ParsedQs): FindOptionsWhere<Meetup> => {
   const findOptionsWhere: FindOptionsWhere<Meetup> = {};
 
   if (query.by_organizer_id != null) {
-    const organizerFilter = (query.by_organizer_id as string)
-      .split(',')
-      .map(Number);
-    if (
-      Joi.array().items(Joi.number()).required().validate(organizerFilter)
-        .error != null
-    ) {
-      // TODO(jan): Throw something here, idk how throwing works lol
-    }
-    findOptionsWhere.organizer_ids = ArrayContains<number>(organizerFilter);
+    const organizerId = Number(query.by_organizer_id);
+    findOptionsWhere.organizer_ids = ArrayOverlap<number>(
+      Number.isNaN(organizerId) ? [] : [organizerId]
+    );
+  }
+
+  if (query.by_city != null) {
+    const city = String(query.by_city);
+    findOptionsWhere.city = ILike(city);
+  }
+
+  if (query.by_state != null) {
+    const state = String(query.by_state);
+    findOptionsWhere.state = ILike(state);
+  }
+
+  if (query.by_country != null) {
+    const country = String(query.by_country);
+    findOptionsWhere.country = ILike(country);
   }
 
   return findOptionsWhere;

--- a/frontend/src/pages/OrganizerDashboard.tsx
+++ b/frontend/src/pages/OrganizerDashboard.tsx
@@ -15,6 +15,7 @@ const OrganizerDashboard = (): JSX.Element => {
   const { user } = useAppSelector((state) => state.user);
   const { data: meetups } = useGetMeetupsQuery({
     organizer_ids: user != null ? [user.id] : [],
+    detail_level: 'detailed',
   });
 
   return (
@@ -34,8 +35,8 @@ const OrganizerDashboard = (): JSX.Element => {
                     name={meetup.name}
                     date={meetup.date}
                     imageUrl={meetup.image_url}
-                    ticketsAvailable={0} // TODO(jan): implement once supported
-                    ticketsTotal={0} // TODO(jan): implement once supported
+                    ticketsAvailable={meetup.tickets?.available ?? NaN}
+                    ticketsTotal={meetup.tickets?.total ?? NaN}
                   />
                 );
               })

--- a/frontend/src/pages/OrganizerDashboard.tsx
+++ b/frontend/src/pages/OrganizerDashboard.tsx
@@ -14,7 +14,7 @@ import { useGetMeetupsQuery } from '../store/meetupSlice';
 const OrganizerDashboard = (): JSX.Element => {
   const { user } = useAppSelector((state) => state.user);
   const { data: meetups } = useGetMeetupsQuery({
-    organizer_ids: user != null ? [user.id] : [],
+    by_organizer_id: user != null ? [user.id] : [],
     detail_level: 'detailed',
   });
 

--- a/frontend/src/store/meetupSlice.ts
+++ b/frontend/src/store/meetupSlice.ts
@@ -4,7 +4,7 @@ import config from '../config';
 
 export interface GetMeetupsOptions {
   detail_level?: string;
-  organizer_ids?: number[];
+  by_organizer_id?: number[];
 }
 
 export const meetupSlice = createApi({

--- a/frontend/src/store/meetupSlice.ts
+++ b/frontend/src/store/meetupSlice.ts
@@ -3,6 +3,7 @@ import type { MeetupInfo } from '../../../backend/src/controllers/meetups';
 import config from '../config';
 
 export interface GetMeetupsOptions {
+  detail_level?: string;
   organizer_ids?: number[];
 }
 

--- a/frontend/src/store/meetupSlice.ts
+++ b/frontend/src/store/meetupSlice.ts
@@ -1,8 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type {
-  FullMeetupInfo,
-  SimpleMeetupInfo,
-} from '../../../backend/src/controllers/meetups';
+import type { MeetupInfo } from '../../../backend/src/controllers/meetups';
 import config from '../config';
 
 export interface GetMeetupsOptions {
@@ -16,14 +13,14 @@ export const meetupSlice = createApi({
     baseUrl: `${config.apiUrl}:${config.apiPort}/`,
   }),
   endpoints: (builder) => ({
-    getMeetups: builder.query<SimpleMeetupInfo[], GetMeetupsOptions>({
+    getMeetups: builder.query<MeetupInfo[], GetMeetupsOptions>({
       query: (options) => ({
         url: `meetups/`,
         params: options,
       }),
       providesTags: ['Meetups'],
     }),
-    getMeetup: builder.query<FullMeetupInfo, number>({
+    getMeetup: builder.query<MeetupInfo, number>({
       query: (id) => ({
         url: `meetups/${id}`,
       }),


### PR DESCRIPTION
Adds query parameters:
* `detail_level` - Get simple or detailed meetup info for getMeetups and getMeetup
* `by_organizer_id`, `by_city`, `by_state`, `by_country` - Filter by respective field for getMeetups
* `sort_by` - Sort by id or date, ascending or descending for getMeetups