### PR TITLE
Fix environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ This project is split into two portions:
 2. Create a `.env` file in `backend/` in the following format (Ports may change depending on database used/personal preference):
 
    ```bash
-   MMS_API_SERVER_URL=http://localhost
+   MMS_API_SERVER_HOSTNAME=localhost
    MMS_API_SERVER_PORT=3000
+   MMS_AUTH_SERVER_HOSTNAME=localhost
+   MMS_AUTH_SERVER_PORT=3000
 
    MMS_DATABASE_HOST=localhost
    MMS_DATABASE_PORT=5432
@@ -85,10 +87,10 @@ This project is split into two portions:
    **Make sure your API URL matches the API Server URL and port you specified in your backend .env file above.**
 
    ```bash
-   MMS_API_SERVER_URL=http://localhost
-   MMS_API_SERVER_PORT=3000
-   MMS_AUTH_SERVER_URL=http://localhost
-   MMS_AUTH_SERVER_PORT=3001
+   VITE_MMS_API_SERVER_URL=http://localhost
+   VITE_MMS_API_SERVER_PORT=3000
+   VITE_MMS_AUTH_SERVER_URL=http://localhost
+   VITE_MMS_AUTH_SERVER_PORT=3001
    ```
 
 3. Run the app.

--- a/backend/src/AuthServer.ts
+++ b/backend/src/AuthServer.ts
@@ -53,9 +53,9 @@ class AuthServer {
     });
   }
 
-  public start = (port: number): void => {
+  public start = (port: number, hostname: string): void => {
     this.express
-      .listen(port, () => {
+      .listen(port, hostname, () => {
         console.log(`Running on port ${port}`);
       })
       .on('error', (err) => {
@@ -65,5 +65,6 @@ class AuthServer {
 }
 
 const port = parseInt(config.authPort);
+const hostname = config.authHostname;
 const server = new AuthServer();
-server.start(port);
+server.start(port, hostname);

--- a/backend/src/Server.ts
+++ b/backend/src/Server.ts
@@ -43,9 +43,9 @@ class Server {
     });
   }
 
-  public start = (port: number): void => {
+  public start = (port: number, hostname: string): void => {
     this.express
-      .listen(port, () => {
+      .listen(port, hostname, () => {
         console.log(`Running on port ${port}`);
       })
       .on('error', (err) => {
@@ -55,5 +55,6 @@ class Server {
 }
 
 const port = parseInt(config.apiPort);
+const hostname = config.apiHostname;
 const server = new Server();
-server.start(port);
+server.start(port, hostname);

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -3,9 +3,9 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 interface Config {
-  apiUrl: string;
+  apiHostname: string;
   apiPort: string;
-  authUrl: string;
+  authHostname: string;
   authPort: string;
   databaseHost: string;
   databasePort: string;
@@ -17,9 +17,9 @@ interface Config {
 }
 
 const config: Config = {
-  apiUrl: process.env.MMS_API_SERVER_URL ?? 'http://localhost',
+  apiHostname: process.env.MMS_API_SERVER_HOSTNAME ?? 'localhost',
   apiPort: process.env.MMS_API_SERVER_PORT ?? '3000',
-  authUrl: process.env.MMS_AUTH_SERVER_URL ?? 'http://localhost',
+  authHostname: process.env.MMS_AUTH_SERVER_HOSTNAME ?? 'localhost',
   authPort: process.env.MMS_AUTH_SERVER_PORT ?? '3001',
   databaseHost: process.env.MMS_DATABASE_HOST ?? 'localhost',
   databasePort: process.env.MMS_DATABASE_PORT ?? '5432',

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,7 +1,3 @@
-import * as dotenv from 'dotenv';
-
-dotenv.config();
-
 interface Config {
   apiUrl: string;
   apiPort: string;
@@ -10,10 +6,10 @@ interface Config {
 }
 
 const config: Config = {
-  apiUrl: process.env.MMS_API_SERVER_URL ?? 'http://localhost',
-  apiPort: process.env.MMS_API_SERVER_PORT ?? '3000',
-  authUrl: process.env.MMS_AUTH_SERVER_URL ?? 'http://localhost',
-  authPort: process.env.MMS_AUTH_SERVER_PORT ?? '3001',
+  apiUrl: import.meta.env.VITE_MMS_API_SERVER_URL ?? 'http://localhost',
+  apiPort: import.meta.env.VITE_MMS_API_SERVER_PORT ?? '3000',
+  authUrl: import.meta.env.VITE_MMS_AUTH_SERVER_URL ?? 'http://localhost',
+  authPort: import.meta.env.VITE_MMS_AUTH_SERVER_PORT ?? '3001',
 };
 
 export default config;


### PR DESCRIPTION
Turns out the ~~url~~ hostname env vars weren't actually being used on the backend, so it was just hosting on local host regardless what the env var is.

Also none of the env vars for frontend were actually being red from the .env because of something about node level vs application level (idk) but basically we have to use `import.meta.env.VITE_*` instead of dotenv for vite