### PR TITLE
Make sidebar button easier to press on mobile

### DIFF
--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   HStack,
   Icon,
+  IconButton,
   Link,
   Menu,
   MenuButton,
@@ -79,7 +80,13 @@ const Nav = ({ sidebar, onOpen }: NavbarProps): JSX.Element => {
         <HStack flexGrow={1} gap={1}>
           {sidebar != null && sidebar ? (
             <Show below={'md'}>
-              <Icon as={FiMenu} onClick={onOpen} />
+              <IconButton
+                icon={<FiMenu />}
+                variant={'outline'}
+                marginRight={'0.5rem'}
+                onClick={onOpen}
+                aria-label={'menu'}
+              />
             </Show>
           ) : null}
           <Link


### PR DESCRIPTION
[notion](https://www.notion.so/janctuary/Add-outline-around-sidebar-hamburger-70fd8420c59d4ead955f1548aea212fa?pvs=4)