### PR TITLE
Improve raffle UI/UX

### DIFF
--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -4,12 +4,21 @@ import { type Meetup } from '../entity/Meetup';
 import { Ticket } from '../entity/Ticket';
 import { type RaffleWinnerResponse } from '../interfaces/rafflesInterfaces';
 import { generateRandomNumber } from '../util/math';
+import {
+  claimRaffleWinnerSchema,
+  rollRaffleWinnerSchema,
+} from '../util/validator';
 
 export const rollRaffleWinner = async (
   req: Request,
   res: Response
 ): Promise<Response> => {
   const meetup = res.locals.meetup as Meetup;
+  const result = rollRaffleWinnerSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json(result.error);
+  }
 
   // Get checked in tickets with raffle entries
   const tickets = await Ticket.find({
@@ -21,14 +30,19 @@ export const rollRaffleWinner = async (
         id: meetup.id,
       },
       is_checked_in: true,
-      raffle_entries: MoreThan(0),
-      raffle_wins: Raw((wins) => `${wins} < raffle_entries`),
+      ...(!result.data.allIn
+        ? {
+            raffle_entries: MoreThan(0),
+            raffle_wins: Raw((wins) => `${wins} < raffle_entries`),
+          }
+        : null),
     },
     select: {
       id: true,
       ticket_holder_display_name: true,
       ticket_holder_first_name: true,
       ticket_holder_last_name: true,
+      raffle_wins: true,
     },
   });
 
@@ -42,6 +56,7 @@ export const rollRaffleWinner = async (
       displayName: winnerTicket.ticket_holder_display_name,
       firstName: winnerTicket.ticket_holder_first_name,
       lastName: winnerTicket.ticket_holder_last_name,
+      wins: winnerTicket.raffle_wins,
     };
 
     return res.status(200).json(response);
@@ -55,6 +70,11 @@ export const claimRaffleWinner = async (
   res: Response
 ): Promise<Response> => {
   const ticket = res.locals.ticket as Ticket;
+  const result = claimRaffleWinnerSchema.safeParse(req.body);
+
+  if (!result.success) {
+    return res.status(400).json(result.error);
+  }
 
   if (ticket.raffle_entries <= 0) {
     return res
@@ -62,7 +82,7 @@ export const claimRaffleWinner = async (
       .json({ message: 'Ticket does not have any raffle entries.' });
   }
 
-  if (ticket.raffle_wins >= ticket.raffle_entries) {
+  if (ticket.raffle_wins >= ticket.raffle_entries && !result.data.force) {
     return res
       .status(400)
       .json({ message: 'Ticket is not eligible for any more wins.' });

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -27,6 +27,8 @@ export const rollRaffleWinner = async (
     select: {
       id: true,
       ticket_holder_display_name: true,
+      ticket_holder_first_name: true,
+      ticket_holder_last_name: true,
     },
   });
 
@@ -35,11 +37,11 @@ export const rollRaffleWinner = async (
     const winnerIndex = generateRandomNumber(0, tickets.length - 1);
     const winnerTicket = tickets[winnerIndex];
 
-    const displayName = winnerTicket.ticket_holder_display_name;
-
     const response: RaffleWinnerResponse = {
       ticketId: winnerTicket.id,
-      displayName,
+      displayName: winnerTicket.ticket_holder_display_name,
+      firstName: winnerTicket.ticket_holder_first_name,
+      lastName: winnerTicket.ticket_holder_last_name,
     };
 
     return res.status(200).json(response);

--- a/backend/src/interfaces/rafflesInterfaces.ts
+++ b/backend/src/interfaces/rafflesInterfaces.ts
@@ -1,4 +1,6 @@
 export interface RaffleWinnerResponse {
   ticketId: number;
   displayName: string;
+  firstName: string;
+  lastName: string;
 }

--- a/backend/src/interfaces/rafflesInterfaces.ts
+++ b/backend/src/interfaces/rafflesInterfaces.ts
@@ -3,4 +3,5 @@ export interface RaffleWinnerResponse {
   displayName: string;
   firstName: string;
   lastName: string;
+  wins: number;
 }

--- a/backend/src/util/validator.ts
+++ b/backend/src/util/validator.ts
@@ -87,3 +87,15 @@ export const editUserSchema = z.object({
 });
 
 export type EditUserPayload = z.infer<typeof editUserSchema>;
+
+export const rollRaffleWinnerSchema = z.object({
+  allIn: z.boolean().optional().default(false),
+});
+
+export type RollRaffleWinnerPayload = z.infer<typeof rollRaffleWinnerSchema>;
+
+export const claimRaffleWinnerSchema = z.object({
+  force: z.boolean().optional().default(false),
+});
+
+export type ClaimRaffleWinnerPayload = z.infer<typeof claimRaffleWinnerSchema>;

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   GridItem,
   Heading,
+  Spacer,
   Text,
   useToast,
   VStack,
@@ -129,9 +130,11 @@ const RafflePage = (): JSX.Element => {
             <Text lineHeight={'6rem'}>Click roll to select a winner</Text>
           )}
         </Box>
+        <Spacer />
         <Grid
           width={'100%'}
           flexGrow={1}
+          maxHeight={'350px'}
           templateRows="repeat(3, 1fr)"
           templateColumns="repeat(2, 1fr)"
           gap={4}

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -2,6 +2,8 @@ import {
   Box,
   Button,
   Flex,
+  Grid,
+  GridItem,
   Heading,
   Text,
   useToast,
@@ -121,43 +123,59 @@ const RafflePage = (): JSX.Element => {
             <Text lineHeight={'6rem'}>Click roll to select a winner</Text>
           )}
         </Box>
-        <Button
-          colorScheme={'green'}
-          flexGrow={1}
+        <Grid
           width={'100%'}
-          onClick={handleClaim}
-          isLoading={isClaimLoading}
-          isDisabled={winner == null}
-        >
-          <Heading fontWeight={'medium'}>Claim</Heading>
-        </Button>
-        <Button
-          colorScheme={'blackAlpha'}
           flexGrow={1}
-          width={'100%'}
-          onClick={handleRoll}
-          isLoading={isRollLoading}
+          templateRows="repeat(3, 1fr)"
+          templateColumns="repeat(2, 1fr)"
+          gap={4}
         >
-          <Heading fontWeight={'medium'}>Roll</Heading>
-        </Button>
-        <Button
-          colorScheme={'blackAlpha'}
-          flexGrow={1}
-          width={'100%'}
-          onClick={handleDisplay}
-          isLoading={isRollLoading}
-        >
-          <Heading fontWeight={'medium'}>Display winner</Heading>
-        </Button>
-        <Button
-          colorScheme={'blackAlpha'}
-          flexGrow={1}
-          width={'100%'}
-          onClick={handleClearDisplay}
-          isLoading={isRollLoading}
-        >
-          <Heading fontWeight={'medium'}>Clear display</Heading>
-        </Button>
+          <GridItem rowSpan={1} colSpan={2}>
+            <Button
+              width={'100%'}
+              height={'100%'}
+              colorScheme={'blackAlpha'}
+              onClick={handleRoll}
+              isLoading={isRollLoading}
+            >
+              <Heading fontWeight={'medium'}>Roll</Heading>
+            </Button>
+          </GridItem>
+          <GridItem rowSpan={1} colSpan={2}>
+            <Button
+              width={'100%'}
+              height={'100%'}
+              colorScheme={'blackAlpha'}
+              onClick={handleDisplay}
+              isLoading={isRollLoading}
+            >
+              <Heading fontWeight={'medium'}>Display winner</Heading>
+            </Button>
+          </GridItem>
+          <GridItem colSpan={1}>
+            <Button
+              width={'100%'}
+              height={'100%'}
+              colorScheme={'blackAlpha'}
+              onClick={handleClaim}
+              isLoading={isClaimLoading}
+              isDisabled={winner == null}
+            >
+              <Heading fontWeight={'medium'}>Claim</Heading>
+            </Button>
+          </GridItem>
+          <GridItem colSpan={1}>
+            <Button
+              width={'100%'}
+              height={'100%'}
+              colorScheme={'blackAlpha'}
+              onClick={handleClearDisplay}
+              isLoading={isRollLoading}
+            >
+              <Heading fontWeight={'medium'}>Clear display</Heading>
+            </Button>{' '}
+          </GridItem>
+        </Grid>
       </VStack>
     </Flex>
   );

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -44,7 +44,7 @@ const RafflePage = (): JSX.Element => {
   );
   const [isDisplayed, setIsDisplayed] = useState<boolean>(false);
 
-  const toast = useToast();
+  const toast = useToast({ position: 'top-right', duration: 2500 });
 
   const handleRoll = (): void => {
     void (async () => {

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -273,9 +273,11 @@ const RafflePage = (): JSX.Element => {
 
           <DrawerBody>
             <VStack spacing={6}>
+              {/* TODO(jan): Implement logic */}
               <FormControl id={'rollQuantity'}>
                 <FormLabel>Roll quantity</FormLabel>
                 <Input
+                  isDisabled
                   type={'number'}
                   inputMode={'numeric'}
                   value={formik.values.rollQuantity}

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -125,6 +125,9 @@ const RafflePage = (): JSX.Element => {
               <Heading size={'4xl'} fontWeight={'medium'}>
                 {winner.displayName ?? ''}
               </Heading>
+              <Text marginTop={'0.3rem'}>
+                {winner.firstName} {winner.lastName}
+              </Text>
             </>
           ) : (
             <Text lineHeight={'6rem'}>Click roll to select a winner</Text>

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -47,6 +47,7 @@ const RafflePage = (): JSX.Element => {
   const handleRoll = (): void => {
     void (async () => {
       await rollRaffleWinner(meetupId);
+      socket.emit('meetup:display', { meetupId, winner: null });
     })();
   };
 
@@ -64,7 +65,8 @@ const RafflePage = (): JSX.Element => {
     }
   };
 
-  const handleClearDisplay = (): void => {
+  const handleClear = (): void => {
+    setWinner(undefined);
     socket.emit('meetup:display', { meetupId, winner: null });
   };
 
@@ -137,6 +139,7 @@ const RafflePage = (): JSX.Element => {
               colorScheme={'blackAlpha'}
               onClick={handleRoll}
               isLoading={isRollLoading}
+              isDisabled={winner != null}
             >
               <Heading fontWeight={'medium'}>Roll</Heading>
             </Button>
@@ -147,7 +150,7 @@ const RafflePage = (): JSX.Element => {
               height={'100%'}
               colorScheme={'blackAlpha'}
               onClick={handleDisplay}
-              isLoading={isRollLoading}
+              isDisabled={winner == null}
             >
               <Heading fontWeight={'medium'}>Display winner</Heading>
             </Button>
@@ -169,10 +172,9 @@ const RafflePage = (): JSX.Element => {
               width={'100%'}
               height={'100%'}
               colorScheme={'blackAlpha'}
-              onClick={handleClearDisplay}
-              isLoading={isRollLoading}
+              onClick={handleClear}
             >
-              <Heading fontWeight={'medium'}>Clear display</Heading>
+              <Heading fontWeight={'medium'}>Clear</Heading>
             </Button>{' '}
           </GridItem>
         </Grid>

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -41,6 +41,7 @@ const RafflePage = (): JSX.Element => {
   const [winner, setWinner] = useState<RaffleWinnerResponse | undefined>(
     undefined
   );
+  const [isDisplayed, setIsDisplayed] = useState<boolean>(false);
 
   const toast = useToast();
 
@@ -48,6 +49,7 @@ const RafflePage = (): JSX.Element => {
     void (async () => {
       await rollRaffleWinner(meetupId);
       socket.emit('meetup:display', { meetupId, winner: null });
+      setIsDisplayed(false);
     })();
   };
 
@@ -62,11 +64,13 @@ const RafflePage = (): JSX.Element => {
   const handleDisplay = (): void => {
     if (winner != null) {
       socket.emit('meetup:display', { meetupId, winner: winner.displayName });
+      setIsDisplayed(true);
     }
   };
 
   const handleClear = (): void => {
     setWinner(undefined);
+    setIsDisplayed(false);
     socket.emit('meetup:display', { meetupId, winner: null });
   };
 
@@ -136,7 +140,7 @@ const RafflePage = (): JSX.Element => {
             <Button
               width={'100%'}
               height={'100%'}
-              colorScheme={'blackAlpha'}
+              colorScheme={winner == null ? 'green' : 'blackAlpha'}
               onClick={handleRoll}
               isLoading={isRollLoading}
               isDisabled={winner != null}
@@ -148,7 +152,9 @@ const RafflePage = (): JSX.Element => {
             <Button
               width={'100%'}
               height={'100%'}
-              colorScheme={'blackAlpha'}
+              colorScheme={
+                winner != null && !isDisplayed ? 'green' : 'blackAlpha'
+              }
               onClick={handleDisplay}
               isDisabled={winner == null}
             >
@@ -159,7 +165,9 @@ const RafflePage = (): JSX.Element => {
             <Button
               width={'100%'}
               height={'100%'}
-              colorScheme={'blackAlpha'}
+              colorScheme={
+                winner != null && isDisplayed ? 'green' : 'blackAlpha'
+              }
               onClick={handleClaim}
               isLoading={isClaimLoading}
               isDisabled={winner == null}
@@ -171,7 +179,13 @@ const RafflePage = (): JSX.Element => {
             <Button
               width={'100%'}
               height={'100%'}
-              colorScheme={'blackAlpha'}
+              colorScheme={
+                winner != null && isDisplayed
+                  ? 'red'
+                  : isDisplayed
+                    ? 'yellow'
+                    : 'blackAlpha'
+              }
               onClick={handleClear}
             >
               <Heading fontWeight={'medium'}>Clear</Heading>

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -1,12 +1,25 @@
 import {
   Box,
   Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
   Flex,
+  FormControl,
+  FormLabel,
   Grid,
   GridItem,
   Heading,
+  Input,
+  Link,
   Spacer,
+  Switch,
   Text,
+  useDisclosure,
   useToast,
   VStack,
 } from '@chakra-ui/react';
@@ -45,6 +58,7 @@ const RafflePage = (): JSX.Element => {
   const [isDisplayed, setIsDisplayed] = useState<boolean>(false);
 
   const toast = useToast({ position: 'top-right', duration: 2500 });
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const handleRoll = (): void => {
     void (async () => {
@@ -134,6 +148,9 @@ const RafflePage = (): JSX.Element => {
           )}
         </Box>
         <Spacer />
+        <Link fontSize={'18px'} textDecoration={'underline'} onClick={onOpen}>
+          More options
+        </Link>
         <Grid
           width={'100%'}
           flexGrow={1}
@@ -199,6 +216,44 @@ const RafflePage = (): JSX.Element => {
           </GridItem>
         </Grid>
       </VStack>
+
+      <Drawer isOpen={isOpen} placement={'bottom'} onClose={onClose}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Options</DrawerHeader>
+
+          <DrawerBody>
+            <VStack spacing={6}>
+              <FormControl>
+                <FormLabel>Roll quantity</FormLabel>
+                <Input type={'number'} inputMode={'numeric'} defaultValue={1} />
+              </FormControl>
+
+              <FormControl display={'flex'} alignItems={'center'}>
+                <FormLabel mb={0}>Display on roll</FormLabel>
+                <Switch />
+              </FormControl>
+
+              <FormControl display={'flex'} alignItems={'center'}>
+                <FormLabel mb={0}>Clear on claim</FormLabel>
+                <Switch />
+              </FormControl>
+
+              <Box width={'100%'}>
+                <Button width={'100%'} height={'3rem'} colorScheme={'red'}>
+                  Roll all in
+                </Button>
+                <Text textAlign={'center'} marginTop={'0.25rem'}>
+                  Previous winners are eligible to wins
+                </Text>
+              </Box>
+            </VStack>
+          </DrawerBody>
+
+          <DrawerFooter></DrawerFooter>
+        </DrawerContent>
+      </Drawer>
     </Flex>
   );
 };

--- a/frontend/src/store/organizerSlice.ts
+++ b/frontend/src/store/organizerSlice.ts
@@ -1,6 +1,10 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { type TicketInfo } from '../../../backend/src/controllers/meetups';
 import { type RaffleWinnerResponse } from '../../../backend/src/interfaces/rafflesInterfaces';
+import {
+  type ClaimRaffleWinnerPayload,
+  type RollRaffleWinnerPayload,
+} from '../../../backend/src/util/validator';
 import config from '../config';
 import { type RootState } from './store';
 
@@ -9,6 +13,16 @@ export interface GetMeetupAttendeesOptions {
   params?: {
     detail_level?: string;
   };
+}
+
+export interface RollRaffleWinnerOptions {
+  meetupId: number;
+  payload?: RollRaffleWinnerPayload;
+}
+
+export interface ClaimRaffleWinnerOptions {
+  ticketId: number;
+  payload?: ClaimRaffleWinnerPayload;
 }
 
 export const organizerSlice = createApi({
@@ -43,16 +57,21 @@ export const organizerSlice = createApi({
       }),
       invalidatesTags: ['Attendees'],
     }),
-    rollRaffleWinner: builder.mutation<RaffleWinnerResponse, number>({
-      query: (meetupId) => ({
-        url: `meetups/${meetupId}/raffle`,
+    rollRaffleWinner: builder.mutation<
+      RaffleWinnerResponse,
+      RollRaffleWinnerOptions
+    >({
+      query: (options) => ({
+        url: `meetups/${options.meetupId}/raffle`,
         method: 'POST',
+        body: options.payload,
       }),
     }),
-    claimRaffleWinner: builder.mutation<void, number>({
-      query: (ticketId) => ({
-        url: `tickets/${ticketId}/claim`,
+    claimRaffleWinner: builder.mutation<void, ClaimRaffleWinnerOptions>({
+      query: (options) => ({
+        url: `tickets/${options.ticketId}/claim`,
         method: 'POST',
+        body: options.payload,
       }),
     }),
   }),


### PR DESCRIPTION
* Reorganizes controls and guide the user through their actions
* Adds options for when to display the winner
* Include first name last name (visible to organizer only)
* Add support to roll for everyone (previous winners are eligible)

[notion task](https://www.notion.so/janctuary/Improve-Raffle-UX-f05eead8028e4e59bd2b5d8607aa37d5?pvs=4)