### PR TITLE
Add backend support for raffle history

### DIFF
--- a/backend/src/Server.ts
+++ b/backend/src/Server.ts
@@ -5,6 +5,7 @@ import { AppDataSource } from './datasource';
 import eventbriteRoutes from './routes/eventbrite';
 import meetupRoutes from './routes/meetups';
 import oauth2Routes from './routes/oauth2';
+import raffleRoutes from './routes/raffles';
 import ticketRoutes from './routes/tickets';
 import userRoutes from './routes/users';
 
@@ -43,6 +44,7 @@ class Server {
     this.express.use('/tickets', ticketRoutes);
     this.express.use('/oauth2/', oauth2Routes);
     this.express.use('/eventbrite', eventbriteRoutes);
+    this.express.use('/raffles', raffleRoutes);
 
     this.express.use('*', (req, res, next) => {
       res.send('Not a valid endpoint.');

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -174,6 +174,9 @@ export const getRaffleRecords = async (
         id: meetup.id,
       },
     },
+    order: {
+      created_at: 'DESC',
+    },
   });
 
   return res.status(200).json(raffleRecords.map(mapRaffleRecordToResponse));

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -2,6 +2,7 @@ import { type Request, type Response } from 'express';
 import { MoreThan, Raw } from 'typeorm';
 import { type Meetup } from '../entity/Meetup';
 import { RaffleRecord } from '../entity/RaffleRecord';
+import { RaffleWinner } from '../entity/RaffleWinner';
 import { Ticket } from '../entity/Ticket';
 import {
   type RaffleRecordResponse,
@@ -22,14 +23,16 @@ const mapRaffleRecordToResponse = (
     isBatchRoll: raffleRecord.is_batch_roll,
     winners: raffleRecord.winners.map((winner) => {
       return {
-        ticketId: winner.id,
-        displayName: winner.ticket_holder_display_name,
-        firstName: winner.ticket_holder_first_name,
-        lastName: winner.ticket_holder_last_name,
-        wins: winner.raffle_wins,
+        ticketId: winner.ticket.id,
+        displayName: winner.ticket.ticket_holder_display_name,
+        firstName: winner.ticket.ticket_holder_first_name,
+        lastName: winner.ticket.ticket_holder_last_name,
+        wins: winner.ticket.raffle_wins,
       } satisfies RaffleWinnerInfo;
     }),
-    winnersClaimed: raffleRecord.winners_claimed.map((claimed) => claimed.id),
+    winnersClaimed: raffleRecord.winners
+      .filter((winner) => winner.claimed)
+      .map((winner) => winner.ticket.id),
     wasDisplayed: raffleRecord.was_displayed,
     createdAt: raffleRecord.created_at,
   } satisfies RaffleRecordResponse;
@@ -80,29 +83,39 @@ export const rollRaffleWinner = async (
       tickets.length - 1
     );
 
-    const winnerTickets: Ticket[] = [];
-    winnerIndices.forEach((winnerIndex) => {
-      winnerTickets.push(tickets[winnerIndex]);
-    });
-
     // Create raffle record
     const raffleRecord = RaffleRecord.create({
       meetup,
       is_batch_roll: result.data.quantity > 1,
-      winners: winnerTickets,
     });
 
     await raffleRecord.save();
 
+    // Create raffle winners for the new raffle record
+    const raffleWinners = winnerIndices.map((winnerIndex, index) =>
+      RaffleWinner.create({
+        raffle_record: raffleRecord,
+        ticket: tickets[winnerIndex],
+        winner_number: index + 1,
+        claimed: false,
+      })
+    );
+
+    raffleWinners.forEach((raffleWinner) => {
+      void (async () => {
+        await raffleWinner.save();
+      })();
+    });
+
     const response: RaffleWinnerResponse = {
       raffleRecordId: Number(raffleRecord.id), // TODO(jan): Shouldn't have to cast here
-      winners: winnerTickets.map((winnerTicket) => {
+      winners: raffleWinners.map((raffleWinner) => {
         return {
-          ticketId: winnerTicket.id,
-          displayName: winnerTicket.ticket_holder_display_name,
-          firstName: winnerTicket.ticket_holder_first_name,
-          lastName: winnerTicket.ticket_holder_last_name,
-          wins: winnerTicket.raffle_wins,
+          ticketId: raffleWinner.ticket.id,
+          displayName: raffleWinner.ticket.ticket_holder_display_name,
+          firstName: raffleWinner.ticket.ticket_holder_first_name,
+          lastName: raffleWinner.ticket.ticket_holder_last_name,
+          wins: raffleWinner.ticket.raffle_wins,
         } satisfies RaffleWinnerInfo;
       }),
     };
@@ -125,7 +138,7 @@ export const claimRaffleWinner = async (
   }
 
   const raffleRecord = await RaffleRecord.findOne({
-    relations: ['winners', 'winners_claimed'],
+    relations: { winners: { ticket: true } },
     where: {
       id: result.data.raffleRecordId,
     },
@@ -134,26 +147,22 @@ export const claimRaffleWinner = async (
   if (raffleRecord == null)
     return res.status(404).json({ message: 'Raffle record not found.' });
 
-  if (
-    raffleRecord.winners.find(
-      (winnerTicket) => winnerTicket.id === ticket.id
-    ) == null
-  )
+  const raffleWinner = raffleRecord.winners.find(
+    (claimedTicket) => claimedTicket.ticket.id === ticket.id
+  );
+
+  if (raffleWinner == null)
     return res
       .status(400)
       .json({ message: 'Ticket is not part of raffle record.' });
 
-  if (
-    raffleRecord.winners_claimed.find(
-      (claimedTicket) => claimedTicket.id === ticket.id
-    ) != null
-  )
+  if (raffleWinner.claimed)
     return res.status(400).json({
       message: 'Ticket has already been claimed for the given raffle record.',
     });
 
-  raffleRecord.winners_claimed.push(ticket);
-  await raffleRecord.save();
+  raffleWinner.claimed = true;
+  await raffleWinner.save();
 
   ticket.raffle_wins++;
   await ticket.save();
@@ -168,7 +177,7 @@ export const getRaffleRecords = async (
   const meetup = res.locals.meetup as Meetup;
 
   const raffleRecords = await RaffleRecord.find({
-    relations: ['winners', 'winners_claimed'],
+    relations: { winners: { ticket: true } },
     where: {
       meetup: {
         id: meetup.id,
@@ -176,6 +185,7 @@ export const getRaffleRecords = async (
     },
     order: {
       created_at: 'DESC',
+      winners: { winner_number: 'ASC' },
     },
   });
 

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -7,7 +7,6 @@ import { Ticket } from '../entity/Ticket';
 import {
   type RaffleRecordResponse,
   type RaffleWinnerInfo,
-  type RaffleWinnerResponse,
 } from '../interfaces/rafflesInterfaces';
 import { generateMultipleRandomNumbers } from '../util/math';
 import {
@@ -107,20 +106,9 @@ export const rollRaffleWinner = async (
       })();
     });
 
-    const response: RaffleWinnerResponse = {
-      raffleRecordId: Number(raffleRecord.id), // TODO(jan): Shouldn't have to cast here
-      winners: raffleWinners.map((raffleWinner) => {
-        return {
-          ticketId: raffleWinner.ticket.id,
-          displayName: raffleWinner.ticket.ticket_holder_display_name,
-          firstName: raffleWinner.ticket.ticket_holder_first_name,
-          lastName: raffleWinner.ticket.ticket_holder_last_name,
-          wins: raffleWinner.ticket.raffle_wins,
-        } satisfies RaffleWinnerInfo;
-      }),
-    };
+    raffleRecord.winners = raffleWinners;
 
-    return res.status(200).json(response);
+    return res.status(200).json(mapRaffleRecordToResponse(raffleRecord));
   }
 
   return res.status(200).end();

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -197,3 +197,27 @@ export const getRaffleRecord = async (
 
   return res.status(200).json(mapRaffleRecordToResponse(raffleRecord));
 };
+
+export const markRaffleRecordAsDisplayed = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { raffle_id } = req.params;
+
+  const raffleRecord = await RaffleRecord.findOne({
+    where: {
+      id: Number(raffle_id),
+    },
+    select: ['was_displayed'],
+  });
+
+  if (raffleRecord == null)
+    return res.status(404).json({ message: 'Invalid raffle record ID.' });
+
+  if (raffleRecord.was_displayed) return res.status(204).end();
+
+  raffleRecord.was_displayed = true;
+  await raffleRecord.save();
+
+  return res.status(200).end();
+};

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -199,9 +199,13 @@ export const getRaffleRecord = async (
   const { raffle_id } = req.params;
 
   const raffleRecord = await RaffleRecord.findOne({
-    relations: ['winners', 'winners_claimed'],
+    relations: { winners: { ticket: true } },
     where: {
       id: Number(raffle_id),
+    },
+    order: {
+      created_at: 'DESC',
+      winners: { winner_number: 'ASC' },
     },
   });
 

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -211,7 +211,6 @@ export const markRaffleRecordAsDisplayed = async (
     where: {
       id: Number(raffle_id),
     },
-    select: ['was_displayed'],
   });
 
   if (raffleRecord == null)

--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -129,3 +129,35 @@ export const claimRaffleWinner = async (
 
   return res.status(200).end();
 };
+
+export const getRaffleRecords = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const meetup = res.locals.meetup as Meetup;
+
+  const raffleRecords = await RaffleRecord.find({
+    where: {
+      meetup: {
+        id: meetup.id,
+      },
+    },
+  });
+
+  return res.status(200).json(raffleRecords);
+};
+
+export const getRaffleRecord = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { raffle_id } = req.params;
+
+  const raffleRecord = await RaffleRecord.findOne({
+    where: {
+      id: Number(raffle_id),
+    },
+  });
+
+  return res.status(200).json(raffleRecord);
+};

--- a/backend/src/datasource.ts
+++ b/backend/src/datasource.ts
@@ -5,6 +5,7 @@ import { EventbriteRecord } from './entity/EventbriteRecord';
 import { Meetup } from './entity/Meetup';
 import { MeetupDisplayRecord } from './entity/MeetupDisplayRecord';
 import { RaffleRecord } from './entity/RaffleRecord';
+import { RaffleWinner } from './entity/RaffleWinner';
 import { Ticket } from './entity/Ticket';
 import { User } from './entity/User';
 
@@ -22,6 +23,7 @@ export const AppDataSource = new DataSource({
     EventbriteRecord,
     MeetupDisplayRecord,
     RaffleRecord,
+    RaffleWinner,
   ],
   synchronize: true,
   logging: false,

--- a/backend/src/datasource.ts
+++ b/backend/src/datasource.ts
@@ -4,6 +4,7 @@ import config from './config';
 import { EventbriteRecord } from './entity/EventbriteRecord';
 import { Meetup } from './entity/Meetup';
 import { MeetupDisplayRecord } from './entity/MeetupDisplayRecord';
+import { RaffleRecord } from './entity/RaffleRecord';
 import { Ticket } from './entity/Ticket';
 import { User } from './entity/User';
 
@@ -14,7 +15,14 @@ export const AppDataSource = new DataSource({
   username: config.databaseUser,
   password: config.databasePassword,
   database: config.databaseName,
-  entities: [User, Meetup, Ticket, EventbriteRecord, MeetupDisplayRecord],
+  entities: [
+    User,
+    Meetup,
+    Ticket,
+    EventbriteRecord,
+    MeetupDisplayRecord,
+    RaffleRecord,
+  ],
   synchronize: true,
   logging: false,
 });

--- a/backend/src/entity/Meetup.ts
+++ b/backend/src/entity/Meetup.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { EventbriteRecord } from './EventbriteRecord';
 import { MeetupDisplayRecord } from './MeetupDisplayRecord';
+import { RaffleRecord } from './RaffleRecord';
 import { Ticket } from './Ticket';
 import { User } from './User';
 
@@ -69,4 +70,7 @@ export class Meetup extends BaseEntity {
 
   @OneToOne(() => MeetupDisplayRecord, (displayRecord) => displayRecord.meetup)
   displayRecord?: MeetupDisplayRecord;
+
+  @OneToMany(() => RaffleRecord, (raffleRecord) => raffleRecord.meetup)
+  raffleRecords: RaffleRecord[];
 }

--- a/backend/src/entity/RaffleRecord.ts
+++ b/backend/src/entity/RaffleRecord.ts
@@ -36,7 +36,7 @@ export class RaffleRecord extends BaseEntity {
 
   @BeforeInsert()
   @BeforeUpdate()
-  ensureArraysSameLength = (): void => {
+  validateClaimedWinners = (): void => {
     if (this.winners_claimed == null) return;
     this.winners_claimed.forEach((claimedWinner) => {
       if (!this.winners.includes(claimedWinner)) {

--- a/backend/src/entity/RaffleRecord.ts
+++ b/backend/src/entity/RaffleRecord.ts
@@ -5,10 +5,13 @@ import {
   Column,
   Entity,
   JoinColumn,
+  JoinTable,
+  ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Meetup } from './Meetup';
+import { Ticket } from './Ticket';
 
 @Entity({ name: 'raffle_record' })
 export class RaffleRecord extends BaseEntity {
@@ -18,11 +21,13 @@ export class RaffleRecord extends BaseEntity {
   @Column({ type: 'boolean' })
   is_batch_roll: boolean;
 
-  @Column({ type: 'bigint', array: true })
-  winners: number[];
+  @ManyToMany(() => Ticket, (ticket) => ticket.id)
+  @JoinTable()
+  winners: Ticket[];
 
-  @Column({ type: 'bigint', array: true, default: '{}' })
-  winners_claimed: number[];
+  @ManyToMany(() => Ticket, (ticket) => ticket.id)
+  @JoinTable()
+  winners_claimed: Ticket[];
 
   @Column({ type: 'boolean', default: 'false' })
   was_displayed: boolean;

--- a/backend/src/entity/RaffleRecord.ts
+++ b/backend/src/entity/RaffleRecord.ts
@@ -1,17 +1,14 @@
 import {
   BaseEntity,
-  BeforeInsert,
-  BeforeUpdate,
   Column,
   Entity,
   JoinColumn,
-  JoinTable,
-  ManyToMany,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Meetup } from './Meetup';
-import { Ticket } from './Ticket';
+import { RaffleWinner } from './RaffleWinner';
 
 @Entity({ name: 'raffle_record' })
 export class RaffleRecord extends BaseEntity {
@@ -21,13 +18,8 @@ export class RaffleRecord extends BaseEntity {
   @Column({ type: 'boolean' })
   is_batch_roll: boolean;
 
-  @ManyToMany(() => Ticket, (ticket) => ticket.id)
-  @JoinTable()
-  winners: Ticket[];
-
-  @ManyToMany(() => Ticket, (ticket) => ticket.id)
-  @JoinTable()
-  winners_claimed: Ticket[];
+  @OneToMany(() => RaffleWinner, (winner) => winner.raffle_record)
+  winners: RaffleWinner[];
 
   @Column({ type: 'boolean', default: 'false' })
   was_displayed: boolean;
@@ -38,17 +30,4 @@ export class RaffleRecord extends BaseEntity {
   @ManyToOne(() => Meetup, (meetup) => meetup.id)
   @JoinColumn({ name: 'meetup_id' })
   meetup: Meetup;
-
-  @BeforeInsert()
-  @BeforeUpdate()
-  validateClaimedWinners = (): void => {
-    if (this.winners_claimed == null) return;
-    this.winners_claimed.forEach((claimedWinner) => {
-      if (!this.winners.includes(claimedWinner)) {
-        throw new Error(
-          'All members of \twinners_claimed\t must be present in \twinners\t'
-        );
-      }
-    });
-  };
 }

--- a/backend/src/entity/RaffleRecord.ts
+++ b/backend/src/entity/RaffleRecord.ts
@@ -1,0 +1,49 @@
+import {
+  BaseEntity,
+  BeforeInsert,
+  BeforeUpdate,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Meetup } from './Meetup';
+
+@Entity({ name: 'raffle_record' })
+export class RaffleRecord extends BaseEntity {
+  @PrimaryGeneratedColumn({ type: 'bigint' })
+  id: number;
+
+  @Column({ type: 'boolean' })
+  is_batch_roll: boolean;
+
+  @Column({ type: 'bigint', array: true })
+  winners: number[];
+
+  @Column({ type: 'bigint', array: true, default: '{}' })
+  winners_claimed: number[];
+
+  @Column({ type: 'boolean', default: 'false' })
+  was_displayed: boolean;
+
+  @Column({ type: 'timestamptz', default: () => 'now()' })
+  created_at: Date;
+
+  @ManyToOne(() => Meetup, (meetup) => meetup.id)
+  @JoinColumn({ name: 'meetup_id' })
+  meetup: Meetup;
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  ensureArraysSameLength = (): void => {
+    if (this.winners_claimed == null) return;
+    this.winners_claimed.forEach((claimedWinner) => {
+      if (!this.winners.includes(claimedWinner)) {
+        throw new Error(
+          'All members of \twinners_claimed\t must be present in \twinners\t'
+        );
+      }
+    });
+  };
+}

--- a/backend/src/entity/RaffleWinner.ts
+++ b/backend/src/entity/RaffleWinner.ts
@@ -1,0 +1,33 @@
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+import { RaffleRecord } from './RaffleRecord';
+import { Ticket } from './Ticket';
+
+@Entity({ name: 'raffle_winner' })
+export class RaffleWinner extends BaseEntity {
+  @PrimaryColumn()
+  raffle_record_id: number;
+
+  @ManyToOne(() => RaffleRecord, (raffleRecord) => raffleRecord.id)
+  @JoinColumn({ name: 'raffle_record_id' })
+  raffle_record: RaffleRecord;
+
+  @PrimaryColumn()
+  ticket_id: number;
+
+  @ManyToOne(() => Ticket, (ticket) => ticket.id)
+  @JoinColumn({ name: 'ticket_id' })
+  ticket: Ticket;
+
+  @Column({ type: 'int' })
+  winner_number: number;
+
+  @Column({ type: 'boolean' })
+  claimed: boolean;
+}

--- a/backend/src/interfaces/rafflesInterfaces.ts
+++ b/backend/src/interfaces/rafflesInterfaces.ts
@@ -5,10 +5,6 @@ export interface RaffleWinnerInfo {
   lastName: string;
   wins: number;
 }
-export interface RaffleWinnerResponse {
-  raffleRecordId: number;
-  winners: RaffleWinnerInfo[];
-}
 
 export interface RaffleRecordResponse {
   id: number;

--- a/backend/src/interfaces/rafflesInterfaces.ts
+++ b/backend/src/interfaces/rafflesInterfaces.ts
@@ -9,3 +9,12 @@ export interface RaffleWinnerResponse {
   raffleRecordId: number;
   winners: RaffleWinnerInfo[];
 }
+
+export interface RaffleRecordResponse {
+  id: number;
+  isBatchRoll: boolean;
+  winners: RaffleWinnerInfo[];
+  winnersClaimed: number[];
+  wasDisplayed: boolean;
+  createdAt: Date;
+}

--- a/backend/src/interfaces/rafflesInterfaces.ts
+++ b/backend/src/interfaces/rafflesInterfaces.ts
@@ -6,5 +6,6 @@ export interface RaffleWinnerInfo {
   wins: number;
 }
 export interface RaffleWinnerResponse {
+  raffleRecordId: number;
   winners: RaffleWinnerInfo[];
 }

--- a/backend/src/routes/meetups.ts
+++ b/backend/src/routes/meetups.ts
@@ -10,7 +10,7 @@ import {
   syncEventbriteAttendees,
   updateMeetup,
 } from '../controllers/meetups';
-import { rollRaffleWinner } from '../controllers/raffles';
+import { getRaffleRecords, rollRaffleWinner } from '../controllers/raffles';
 import { createTicket, updateTicketViaWebhook } from '../controllers/tickets';
 import { Rule, authChecker } from '../middleware/authChecker';
 
@@ -74,5 +74,11 @@ router.post(
 );
 
 router.get('/:meetup_id/idle-images', getMeetupIdleImages as RequestHandler);
+
+router.get(
+  '/:meetup_id/raffles',
+  authChecker() as RequestHandler,
+  getRaffleRecords as RequestHandler
+);
 
 export default router;

--- a/backend/src/routes/raffles.ts
+++ b/backend/src/routes/raffles.ts
@@ -1,0 +1,13 @@
+import express, { type RequestHandler } from 'express';
+import { getRaffleRecord } from '../controllers/raffles';
+import { authChecker } from '../middleware/authChecker';
+
+const router = express.Router();
+
+router.get(
+  '/:raffle_id',
+  authChecker() as RequestHandler,
+  getRaffleRecord as RequestHandler
+);
+
+export default router;

--- a/backend/src/routes/raffles.ts
+++ b/backend/src/routes/raffles.ts
@@ -1,5 +1,8 @@
 import express, { type RequestHandler } from 'express';
-import { getRaffleRecord } from '../controllers/raffles';
+import {
+  getRaffleRecord,
+  markRaffleRecordAsDisplayed,
+} from '../controllers/raffles';
 import { authChecker } from '../middleware/authChecker';
 
 const router = express.Router();
@@ -8,6 +11,12 @@ router.get(
   '/:raffle_id',
   authChecker() as RequestHandler,
   getRaffleRecord as RequestHandler
+);
+
+router.post(
+  '/:raffle_id/displayed',
+  authChecker() as RequestHandler,
+  markRaffleRecordAsDisplayed as RequestHandler
 );
 
 export default router;

--- a/backend/src/util/validator.ts
+++ b/backend/src/util/validator.ts
@@ -97,7 +97,8 @@ export const rollRaffleWinnerSchema = z.object({
 export type RollRaffleWinnerPayload = z.input<typeof rollRaffleWinnerSchema>;
 
 export const claimRaffleWinnerSchema = z.object({
-  force: z.boolean().optional().default(false),
+  raffleRecordId: z.number(),
+  force: z.boolean().default(false).optional(),
 });
 
-export type ClaimRaffleWinnerPayload = z.infer<typeof claimRaffleWinnerSchema>;
+export type ClaimRaffleWinnerPayload = z.input<typeof claimRaffleWinnerSchema>;

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -57,6 +57,7 @@ const RafflePage = (): JSX.Element => {
   );
   const [claimIndex, setClaimIndex] = useState<number>(0);
   const [claimedArray, setClaimedArray] = useState<boolean[]>([]); // Used for disabling buttons on batch rolls
+  const [raffleRecordId, setRaffleRecordId] = useState<number | null>(null);
   const [isDisplayed, setIsDisplayed] = useState<boolean>(false);
   const [isAllIn, setIsAllIn] = useState<boolean>(false);
 
@@ -93,10 +94,10 @@ const RafflePage = (): JSX.Element => {
     const winnerIndex = Number(event.currentTarget.id);
     setClaimIndex(winnerIndex);
     void (async () => {
-      if (winners != null) {
+      if (raffleRecordId != null && winners != null) {
         await claimRaffleWinner({
           ticketId: winners[winnerIndex].ticketId,
-          payload: { force: isAllIn },
+          payload: { raffleRecordId, force: isAllIn },
         });
       }
     })();
@@ -141,6 +142,7 @@ const RafflePage = (): JSX.Element => {
         }
       }
 
+      setRaffleRecordId(rollResult.raffleRecordId);
       setWinners(rollResult.winners);
 
       // Initialize claimed status array for batch rolls


### PR DESCRIPTION
Basically logs raffle rolls in the db to see who was previously rolled, who claimed, when it was rolled, and whether it was displayed.

Only includes front end changes to not break it

Undo functionality is not included, but will keep in mind for the future.