### PR TITLE
Add `claimed` as an attribute to raffle winner interface

### DIFF
--- a/backend/src/controllers/raffles.ts
+++ b/backend/src/controllers/raffles.ts
@@ -28,11 +28,9 @@ const mapRaffleRecordToResponse = (
         firstName: winner.ticket.ticket_holder_first_name,
         lastName: winner.ticket.ticket_holder_last_name,
         wins: winner.ticket.raffle_wins,
+        claimed: winner.claimed,
       } satisfies RaffleWinnerInfo;
     }),
-    winnersClaimed: raffleRecord.winners
-      .filter((winner) => winner.claimed)
-      .map((winner) => winner.ticket.id),
     wasDisplayed: raffleRecord.was_displayed,
     createdAt: raffleRecord.created_at,
   } satisfies RaffleRecordResponse;

--- a/backend/src/interfaces/rafflesInterfaces.ts
+++ b/backend/src/interfaces/rafflesInterfaces.ts
@@ -4,13 +4,13 @@ export interface RaffleWinnerInfo {
   firstName: string;
   lastName: string;
   wins: number;
+  claimed: boolean;
 }
 
 export interface RaffleRecordResponse {
   id: number;
   isBatchRoll: boolean;
   winners: RaffleWinnerInfo[];
-  winnersClaimed: number[];
   wasDisplayed: boolean;
   createdAt: Date;
 }

--- a/frontend/src/components/RafflePage/RaffleHistoryCard.tsx
+++ b/frontend/src/components/RafflePage/RaffleHistoryCard.tsx
@@ -42,9 +42,7 @@ const RaffleHistoryCard = ({
         {raffleRecord.winners.map((winner, index) => (
           <Flex key={index} justifyContent={'space-between'}>
             <Text noOfLines={1}>{winner.displayName}</Text>
-            {raffleRecord.winnersClaimed.includes(winner.ticketId) ? (
-              <Tag colorScheme={'green'}>Claimed</Tag>
-            ) : null}
+            {winner.claimed ? <Tag colorScheme={'green'}>Claimed</Tag> : null}
           </Flex>
         ))}
         <Flex justifyContent={'space-between'} marginTop={'0.5rem'}>

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -244,9 +244,7 @@ const RafflePage = (): JSX.Element => {
                           }
                           id={String(index)}
                           onClick={handleClaim}
-                          isDisabled={raffleRecord.winnersClaimed.includes(
-                            winner.ticketId
-                          )}
+                          isDisabled={winner.claimed}
                         >
                           Claim
                         </Button>
@@ -353,10 +351,7 @@ const RafflePage = (): JSX.Element => {
                 onClick={handleClaim}
                 isLoading={isClaimLoading}
                 isDisabled={
-                  raffleRecordId == null ||
-                  raffleRecord?.winnersClaimed.includes(
-                    raffleRecord.winners[0].ticketId
-                  )
+                  raffleRecordId == null || raffleRecord?.winners[0].claimed
                 }
               >
                 <Heading fontWeight={'medium'}>Claim</Heading>


### PR DESCRIPTION
Remove claimed array in raffle record response. This was vestigial of an older incorrect implementation