### PR TITLE
Fix text overflow on raffle pages

### DIFF
--- a/frontend/src/pages/MeetupDisplayPage.tsx
+++ b/frontend/src/pages/MeetupDisplayPage.tsx
@@ -191,12 +191,21 @@ const MeetupDisplayPage = (): JSX.Element => {
                   spacing={5}
                   ref={ref}
                 >
-                  <Text fontSize={'144px'} noOfLines={1}>
+                  <Text
+                    fontSize={'144px'}
+                    noOfLines={1}
+                    wordBreak={'break-all'}
+                  >
                     {winners[0]}
                   </Text>
                   {losers != null
                     ? shuffleArray(losers).map((loser, index) => (
-                        <Text key={index} fontSize={'144px'} noOfLines={1}>
+                        <Text
+                          key={index}
+                          fontSize={'144px'}
+                          noOfLines={1}
+                          wordBreak={'break-all'}
+                        >
                           {loser}
                         </Text>
                       ))

--- a/frontend/src/pages/RafflePage.tsx
+++ b/frontend/src/pages/RafflePage.tsx
@@ -270,7 +270,12 @@ const RafflePage = (): JSX.Element => {
                         flexDirection={'row'}
                         justifyContent={'space-between'}
                       >
-                        <Text fontSize={'2xl'}>
+                        <Text
+                          fontSize={'2xl'}
+                          noOfLines={1}
+                          minWidth={0}
+                          wordBreak={'break-all'}
+                        >
                           {`${index + 1}. ${winner.displayName}`}
                         </Text>
                         <Button
@@ -293,12 +298,16 @@ const RafflePage = (): JSX.Element => {
                 </VStack>
               </Box>
             ) : (
-              <>
+              <Box height={0}>
                 {/* DIsplay for single person roll */}
                 <Text>WINNER</Text>
-                <Heading size={'4xl'} fontWeight={'medium'}>
+                <Text
+                  fontSize={'3rem'}
+                  fontWeight={'medium'}
+                  wordBreak={'break-all'}
+                >
                   {raffleRecord.winners[0].displayName ?? ''}
-                </Heading>
+                </Text>
                 <Text marginTop={'0.3rem'}>
                   {raffleRecord.winners[0].firstName}{' '}
                   {raffleRecord.winners[0].lastName}
@@ -309,7 +318,7 @@ const RafflePage = (): JSX.Element => {
                     {raffleRecord.winners[0].wins > 1 ? 's' : null}
                   </Text>
                 ) : null}
-              </>
+              </Box>
             )
           ) : (
             <Text lineHeight={'6rem'}>Click roll to select a winner</Text>


### PR DESCRIPTION
`word-break: break-all;` my beloved

fixes #87 