### PR TITLE
Use red for destructive in light mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,7 +18,7 @@
   --muted-foreground: oklch(0.5341 0.0078 97.4503);
   --accent: oklch(0.9245 0.0138 92.9892);
   --accent-foreground: oklch(0.2671 0.0196 98.9390);
-  --destructive: oklch(0.1908 0.0020 106.5859);
+  --destructive: oklch(0.6368 0.2078 25.3313);
   --destructive-foreground: oklch(1.0000 0 0);
   --border: oklch(0.8847 0.0069 97.3627);
   --input: oklch(0.7621 0.0156 98.3528);


### PR DESCRIPTION
Claude theme had it black originally.... makes form validation errors not super obvious in light mode