### PR TITLE
Allow floats for meetup duration

### DIFF
--- a/backend/src/entity/Meetup.ts
+++ b/backend/src/entity/Meetup.ts
@@ -36,7 +36,7 @@ export class Meetup extends BaseEntity {
   @Column({ type: 'int' })
   capacity: number;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'float' })
   duration_hours: number;
 
   @Column({ type: 'varchar', length: 255 })

--- a/backend/src/migrations/1782963907165-DurationHoursFloat.ts
+++ b/backend/src/migrations/1782963907165-DurationHoursFloat.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DurationHoursFloat1782963907165 implements MigrationInterface {
+    name = 'DurationHoursFloat1782963907165'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meetups" ALTER COLUMN "duration_hours" TYPE double precision`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meetups" ALTER COLUMN "duration_hours" TYPE integer USING ceil("duration_hours")`);
+    }
+
+}


### PR DESCRIPTION
couldn't reproduce the crash, but having a float for meetup duration is still useful

closes #43 