### PR TITLE
Improve navigation on organizer and admin pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <link rel="manifest" href="/manifest.json" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link

--- a/frontend/src/components/BottomNav/BottomNav.tsx
+++ b/frontend/src/components/BottomNav/BottomNav.tsx
@@ -1,0 +1,141 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { cn } from '@/lib/utils';
+import {
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react';
+import { FiMoreHorizontal } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
+import { type SidebarItem } from '../Sidebar/Sidebar';
+
+interface BottomNavProps {
+  items: SidebarItem[];
+  value: string;
+  setValue: Dispatch<SetStateAction<string>>;
+  className?: string;
+}
+
+/**
+ * Total slots to show in the bar. When there are more items than slots, the
+ * final slot becomes a "More" button that reveals the overflow in a sheet.
+ */
+const MAX_SLOTS = 5;
+
+/**
+ * Mobile bottom navigation. Mirrors the desktop {@link ../Sidebar/Sidebar}
+ * using the same items; the active destination is highlighted in the primary
+ * color.
+ */
+const BottomNav = ({
+  items,
+  value,
+  setValue,
+  className,
+}: BottomNavProps): ReactNode => {
+  const navigate = useNavigate();
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const hasOverflow = items.length > MAX_SLOTS;
+  const primaryItems = hasOverflow ? items.slice(0, MAX_SLOTS - 1) : items;
+  const overflowItems = hasOverflow ? items.slice(MAX_SLOTS - 1) : [];
+  const overflowActive = overflowItems.some((item) => item.value === value);
+
+  const go = (item: SidebarItem): void => {
+    setValue(item.value);
+    void navigate(item.url);
+  };
+
+  return (
+    <nav
+      className={cn(
+        // Clear the iOS home indicator without reserving its full inset, which
+        // would push the buttons too high in the bar.
+        'bg-background w-full shrink-0 border-t pt-1 pb-[max(0px,calc(env(safe-area-inset-bottom)-0.75rem))]',
+        className
+      )}
+    >
+      <div className="flex h-16 items-stretch">
+        {primaryItems.map((item) => {
+          const Icon = item.icon;
+          const active = item.value === value;
+          return (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => {
+                go(item);
+              }}
+              aria-current={active ? 'page' : undefined}
+              className={cn(
+                'flex flex-1 flex-col items-center justify-center gap-1 text-xs',
+                active ? 'text-primary' : 'text-muted-foreground'
+              )}
+            >
+              <Icon size={20} />
+              <span className="max-w-full truncate px-1">{item.name}</span>
+            </button>
+          );
+        })}
+
+        {hasOverflow && (
+          <Sheet open={moreOpen} onOpenChange={setMoreOpen}>
+            <button
+              type="button"
+              onClick={() => {
+                setMoreOpen(true);
+              }}
+              aria-current={overflowActive ? 'page' : undefined}
+              className={cn(
+                'flex flex-1 flex-col items-center justify-center gap-1 text-xs',
+                overflowActive ? 'text-primary' : 'text-muted-foreground'
+              )}
+            >
+              <FiMoreHorizontal size={20} />
+              <span>More</span>
+            </button>
+            <SheetContent side="bottom" className="rounded-t-xl">
+              <SheetHeader>
+                <SheetTitle>More</SheetTitle>
+              </SheetHeader>
+              <div className="grid grid-cols-3 gap-3 px-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
+                {overflowItems.map((item) => {
+                  const Icon = item.icon;
+                  const active = item.value === value;
+                  return (
+                    <button
+                      key={item.value}
+                      type="button"
+                      onClick={() => {
+                        go(item);
+                        setMoreOpen(false);
+                      }}
+                      aria-current={active ? 'page' : undefined}
+                      className={cn(
+                        'flex flex-col items-center justify-center gap-2 rounded-lg border p-4 text-sm',
+                        active
+                          ? 'border-primary text-primary'
+                          : 'text-muted-foreground'
+                      )}
+                    >
+                      <Icon size={22} />
+                      <span className="text-center">{item.name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </SheetContent>
+          </Sheet>
+        )}
+      </div>
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/frontend/src/components/Page/Page.tsx
+++ b/frontend/src/components/Page/Page.tsx
@@ -2,13 +2,18 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
 import BottomNav from '../BottomNav/BottomNav';
 import Navbar from '../Navbar/Navbar';
-import Sidebar, { type SidebarItem } from '../Sidebar/Sidebar';
+import Sidebar, {
+  type SidebarBackLink,
+  type SidebarItem,
+} from '../Sidebar/Sidebar';
 
 export interface PageProps {
   children: ReactNode;
   sidebarItems?: SidebarItem[];
   sidebarValue?: string;
   setSidebarValue?: Dispatch<SetStateAction<string>>;
+  /** Optional link shown atop the sidebar for returning to a parent view. */
+  sidebarBackTo?: SidebarBackLink;
 }
 
 const Page = ({
@@ -16,6 +21,7 @@ const Page = ({
   children,
   sidebarValue,
   setSidebarValue,
+  sidebarBackTo,
 }: PageProps): ReactNode => {
   const hasSidebar =
     sidebarItems != null && sidebarValue != null && setSidebarValue != null;
@@ -31,6 +37,7 @@ const Page = ({
               sidebarItems={sidebarItems}
               value={sidebarValue}
               setValue={setSidebarValue}
+              backTo={sidebarBackTo}
             />
             <SidebarInset className="min-h-0 overflow-auto bg-transparent">
               {children}

--- a/frontend/src/components/Page/Page.tsx
+++ b/frontend/src/components/Page/Page.tsx
@@ -1,7 +1,8 @@
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
+import BottomNav from '../BottomNav/BottomNav';
 import Navbar from '../Navbar/Navbar';
 import Sidebar, { type SidebarItem } from '../Sidebar/Sidebar';
-import { useDisclosure } from '@/hooks/useDisclosure';
 
 export interface PageProps {
   children: ReactNode;
@@ -16,29 +17,38 @@ const Page = ({
   sidebarValue,
   setSidebarValue,
 }: PageProps): ReactNode => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const hasSidebar =
+    sidebarItems != null && sidebarValue != null && setSidebarValue != null;
 
   return (
     <div className="bg-muted flex h-svh flex-col">
-      <Navbar sidebar={sidebarItems != null} onOpen={onOpen} />
-      <div className="h-full w-auto overflow-hidden">
-        {sidebarItems != null &&
-        sidebarValue != null &&
-        setSidebarValue != null ? (
-          <div className="flex h-full flex-row">
+      <Navbar />
+      {hasSidebar ? (
+        <>
+          {/* Desktop: navigation rail beside the content. */}
+          <SidebarProvider className="min-h-0 flex-1">
             <Sidebar
               sidebarItems={sidebarItems}
-              isOpen={isOpen}
-              onClose={onClose}
               value={sidebarValue}
               setValue={setSidebarValue}
             />
-            <div className="relative grow overflow-auto">{children}</div>
-          </div>
-        ) : (
+            <SidebarInset className="min-h-0 overflow-auto bg-transparent">
+              {children}
+            </SidebarInset>
+          </SidebarProvider>
+          {/* Mobile: bottom navigation takes over for the sidebar. */}
+          <BottomNav
+            items={sidebarItems}
+            value={sidebarValue}
+            setValue={setSidebarValue}
+            className="md:hidden"
+          />
+        </>
+      ) : (
+        <div className="h-full w-auto overflow-hidden">
           <div className="relative h-full overflow-auto">{children}</div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,17 +1,15 @@
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
-import { cn } from '@/lib/utils';
+  Sidebar as SidebarPrimitive,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
 import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
 import { type IconType } from 'react-icons';
 import { useNavigate } from 'react-router-dom';
-
-/**
- * Adapted from https://chakra-templates.vercel.app/navigation/sidebar
- */
 
 export interface SidebarItem {
   name: string;
@@ -22,116 +20,53 @@ export interface SidebarItem {
 
 interface SidebarProps {
   sidebarItems: SidebarItem[];
-  isOpen: boolean;
-  onClose: () => void;
   value: string;
   setValue: Dispatch<SetStateAction<string>>;
 }
 
+/**
+ * Desktop navigation rail built on shadcn's sidebar primitives. Hidden on
+ * mobile, where {@link ../BottomNav/BottomNav BottomNav} takes over instead.
+ */
 const Sidebar = ({
   sidebarItems,
-  isOpen,
-  onClose,
   value,
   setValue,
 }: SidebarProps): ReactNode => {
-  return (
-    <div className="bg-muted h-full">
-      <SidebarContent
-        sidebarItems={sidebarItems}
-        onClose={onClose}
-        className="hidden md:block"
-        value={value}
-        setValue={setValue}
-      />
-      <Sheet
-        open={isOpen}
-        onOpenChange={(open) => {
-          if (!open) onClose();
-        }}
-      >
-        <SheetContent side="left" className="w-60 p-0">
-          <SheetHeader className="sr-only">
-            <SheetTitle>Navigation</SheetTitle>
-          </SheetHeader>
-          <SidebarContent
-            sidebarItems={sidebarItems}
-            onClose={onClose}
-            value={value}
-            setValue={setValue}
-          />
-        </SheetContent>
-      </Sheet>
-    </div>
-  );
-};
-
-interface SidebarContentProps extends React.ComponentProps<'div'> {
-  sidebarItems: SidebarItem[];
-  onClose: () => void;
-  value: string;
-  setValue: Dispatch<SetStateAction<string>>;
-}
-
-const SidebarContent = ({
-  sidebarItems,
-  onClose,
-  value,
-  setValue,
-  className,
-  ...rest
-}: SidebarContentProps): ReactNode => {
   const navigate = useNavigate();
 
   return (
-    <div
-      className={cn('bg-background h-full w-full border-r md:w-60', className)}
-      {...rest}
+    <SidebarPrimitive
+      collapsible="none"
+      className="hidden h-full border-r md:flex"
     >
-      {sidebarItems.map((link) => (
-        <NavItem
-          key={link.value}
-          icon={link.icon}
-          selected={link.value === value}
-          onClick={() => {
-            setValue(link.value);
-            void navigate(link.url);
-            onClose();
-          }}
-        >
-          {link.name}
-        </NavItem>
-      ))}
-    </div>
-  );
-};
-
-interface NavItemProps {
-  icon: IconType;
-  children: ReactNode;
-  selected: boolean;
-  onClick: () => void;
-}
-
-const NavItem = ({
-  icon: IconComponent,
-  children,
-  selected,
-  onClick,
-}: NavItemProps): ReactNode => {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      className={cn(
-        'flex cursor-pointer items-center gap-4 p-4 hover:bg-accent hover:text-accent-foreground',
-        selected ? 'bg-primary text-primary-foreground' : ''
-      )}
-    >
-      {IconComponent != null && <IconComponent className="size-4" />}
-      {children}
-    </div>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {sidebarItems.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <SidebarMenuItem key={item.value}>
+                    <SidebarMenuButton
+                      isActive={item.value === value}
+                      onClick={() => {
+                        setValue(item.value);
+                        void navigate(item.url);
+                      }}
+                      className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:hover:bg-primary data-[active=true]:hover:text-primary-foreground"
+                    >
+                      <Icon />
+                      <span>{item.name}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </SidebarPrimitive>
   );
 };
 

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -3,12 +3,14 @@ import {
   SidebarContent,
   SidebarGroup,
   SidebarGroupContent,
+  SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
 import { type IconType } from 'react-icons';
+import { FiArrowLeft } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
 export interface SidebarItem {
@@ -18,10 +20,17 @@ export interface SidebarItem {
   url: string;
 }
 
+export interface SidebarBackLink {
+  label: string;
+  url: string;
+}
+
 interface SidebarProps {
   sidebarItems: SidebarItem[];
   value: string;
   setValue: Dispatch<SetStateAction<string>>;
+  /** Optional link rendered above the nav for returning to a parent view. */
+  backTo?: SidebarBackLink;
 }
 
 /**
@@ -32,6 +41,7 @@ const Sidebar = ({
   sidebarItems,
   value,
   setValue,
+  backTo,
 }: SidebarProps): ReactNode => {
   const navigate = useNavigate();
 
@@ -40,6 +50,23 @@ const Sidebar = ({
       collapsible="none"
       className="hidden h-full border-r md:flex"
     >
+      {backTo != null ? (
+        <SidebarHeader>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                className="text-muted-foreground"
+                onClick={() => {
+                  void navigate(backTo.url);
+                }}
+              >
+                <FiArrowLeft />
+                <span>{backTo.label}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
+      ) : null}
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,0 +1,726 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { PanelLeftIcon } from "lucide-react"
+import { Slot } from "radix-ui"
+
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  isActive?: boolean
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot.Root : "button"
+  const { isMobile, state } = useSidebar()
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+
+  if (!tooltip) {
+    return button
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean
+  showOnHover?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "button"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none",
+        "peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  }, [])
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+  size?: "sm" | "md"
+  isActive?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "a"
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -608,6 +608,7 @@ function SidebarMenuSkeleton({
 }) {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
+    // eslint-disable-next-line react-hooks/purity -- vendored: random skeleton width
     return `${Math.floor(Math.random() * 40) + 50}%`
   }, [])
 

--- a/frontend/src/hooks/use-mobile.ts
+++ b/frontend/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/frontend/src/pages/ManageMeetupHomePage.tsx
+++ b/frontend/src/pages/ManageMeetupHomePage.tsx
@@ -82,75 +82,54 @@ const ManageMeetupHomePage = (): ReactNode => {
   }
 
   return (
-    <div className="m-4 flex flex-col justify-center">
+    <div className="p-4">
       {meetup != null && attendees != null ? (
-        <div className="grid grid-cols-2 [grid-template-rows:repeat(3,100px)] gap-4 py-3">
-          <div>
-            {/* Show how many have checked in if meetup is currently happening, otherwise show how many have signed up */}
-            <FractionCard
-              numerator={
-                isHappeningNow
-                  ? attendees.filter((attendee) => attendee.is_checked_in)
-                      .length
-                  : (meetup.tickets?.total ?? 0) -
-                    (meetup.tickets?.available ?? 0)
-              }
-              denominator={
-                isHappeningNow ? attendees.length : (meetup.tickets?.total ?? 0)
-              }
-              label={isHappeningNow ? 'checked in' : 'signed up'}
-              onClick={() => {
-                void navigate(
-                  `/meetup/${meetupId}/manage/${
-                    isHappeningNow ? 'checkin' : 'attendees'
-                  }`
-                );
-              }}
-              className="w-full cursor-pointer"
-            />
-          </div>
+        <div className="grid grid-cols-2 [grid-template-rows:repeat(2,100px)] gap-4">
+          {/* Show how many have checked in if meetup is currently happening, otherwise show how many have signed up */}
+          <FractionCard
+            numerator={
+              isHappeningNow
+                ? attendees.filter((attendee) => attendee.is_checked_in).length
+                : (meetup.tickets?.total ?? 0) -
+                  (meetup.tickets?.available ?? 0)
+            }
+            denominator={
+              isHappeningNow ? attendees.length : (meetup.tickets?.total ?? 0)
+            }
+            label={isHappeningNow ? 'checked in' : 'signed up'}
+            onClick={() => {
+              void navigate(
+                `/meetup/${meetupId}/manage/${
+                  isHappeningNow ? 'checkin' : 'attendees'
+                }`
+              );
+            }}
+            className="flex h-full w-full cursor-pointer items-center justify-center"
+          />
 
-          <div>
-            {/* Show detailed countdown until meetup end if meetup is currently happening, otherwise show relative time until start of meetup or end of meetup */}
-            <CountDownCard
-              date={
-                hasStarted || hasEnded
-                  ? dayjs(meetup.date).add(meetup.duration_hours ?? 0, 'hours')
-                  : dayjs(meetup.date)
-              }
-              futureText={!hasStarted ? 'left' : 'until end'}
-              pastText={'ago'}
-              className="w-full"
-              simple={!isHappeningNow}
-            />
-          </div>
+          {/* Show detailed countdown until meetup end if meetup is currently happening, otherwise show relative time until start of meetup or end of meetup */}
+          <CountDownCard
+            date={
+              hasStarted || hasEnded
+                ? dayjs(meetup.date).add(meetup.duration_hours ?? 0, 'hours')
+                : dayjs(meetup.date)
+            }
+            futureText={!hasStarted ? 'left' : 'until end'}
+            pastText={'ago'}
+            className="flex h-full w-full items-center justify-center"
+            simple={!isHappeningNow}
+          />
 
-          {/* TODO(jan): Clean this up. This was done last minute before Roundup */}
-          <div className="col-span-2">
-            <div className="bg-card text-card-foreground size-full rounded-md shadow-sm">
-              <div className="grid h-full grid-cols-2">
-                <div className="flex h-full flex-col items-center justify-center">
-                  <p className="text-4xl">{numRaffleRolls}</p>
-                  <p className="text-xs">WINNERS</p>
-                </div>
-
-                <div className="flex h-full flex-col items-center justify-center">
-                  <p className="text-4xl">{numRaffleClaims}</p>
-                  <p className="text-xs">CLAIMED</p>
-                </div>
-              </div>
+          <div className="bg-card text-card-foreground col-span-2 grid grid-cols-2 rounded-md shadow-sm">
+            <div className="flex flex-col items-center justify-center">
+              <p className="text-4xl">{numRaffleRolls}</p>
+              <p className="text-xs">WINNERS</p>
             </div>
-          </div>
 
-          <div className="col-span-2">
-            <Button
-              className="size-full"
-              onClick={() => {
-                void navigate(`/meetup/${meetupId}/manage/raffle`);
-              }}
-            >
-              Raffles
-            </Button>
+            <div className="flex flex-col items-center justify-center">
+              <p className="text-4xl">{numRaffleClaims}</p>
+              <p className="text-xs">CLAIMED</p>
+            </div>
           </div>
         </div>
       ) : null}

--- a/frontend/src/pages/ManageMeetupPage.tsx
+++ b/frontend/src/pages/ManageMeetupPage.tsx
@@ -114,6 +114,7 @@ const ManageMeetupPage = ({ children }: ManageMeetupPageProps): ReactNode => {
       sidebarItems={sidebarItems}
       sidebarValue={sidebarValue}
       setSidebarValue={setSidebarValue}
+      sidebarBackTo={{ label: 'Organizer Dashboard', url: '/organizer' }}
     >
       <div className="flex h-full flex-col">
         <h1 className="mt-4 line-clamp-2 w-full shrink-0 px-6 text-center text-3xl font-bold">

--- a/frontend/src/pages/ManageMeetupPage.tsx
+++ b/frontend/src/pages/ManageMeetupPage.tsx
@@ -77,16 +77,16 @@ const ManageMeetupPage = ({ children }: ManageMeetupPageProps): ReactNode => {
       url: `/meetup/${meetupId}/manage/raffle`,
     },
     {
-      name: 'Display',
-      value: 'display',
-      icon: FiMonitor,
-      url: `/meetup/${meetupId}/manage/display`,
-    },
-    {
       name: 'Attendees',
       value: 'attendees',
       icon: FiUsers,
       url: `/meetup/${meetupId}/manage/attendees`,
+    },
+    {
+      name: 'Display',
+      value: 'display',
+      icon: FiMonitor,
+      url: `/meetup/${meetupId}/manage/display`,
     },
     {
       name: 'Meetup Settings',


### PR DESCRIPTION
* Moves to shadcn's sidebar instead of the chakra clone
* Adds navbar for smaller devices, much easier to use on larger phones

<img width="2332" height="4160" alt="image" src="https://github.com/user-attachments/assets/2b995c12-3b38-4767-a6c9-15223b1dd81f" />
<img width="5088" height="4090" alt="image" src="https://github.com/user-attachments/assets/b6225f4b-d1e6-4cfe-9258-6980854e5c77" />
