### PR TITLE
Don't allow user to submit before an image upload finishes

### DIFF
--- a/frontend/src/components/Forms/EditableFormCard.tsx
+++ b/frontend/src/components/Forms/EditableFormCard.tsx
@@ -15,6 +15,7 @@ interface MeetupDisplaySettingsProps extends React.ComponentProps<'div'> {
   isEditable: boolean;
   isSubmitLoading?: boolean;
   isFormInvalid?: boolean;
+  isSubmitDisabled?: boolean;
   editDisabled?: boolean;
   editDisabledReason?: string;
   onEditEnter: () => void;
@@ -27,6 +28,7 @@ const EditableFormCard = ({
   isEditable,
   isSubmitLoading,
   isFormInvalid,
+  isSubmitDisabled,
   editDisabled,
   editDisabledReason,
   onEditEnter,
@@ -65,7 +67,11 @@ const EditableFormCard = ({
         <div className="flex justify-end">
           <Button
             onClick={onEditSubmit}
-            disabled={(isFormInvalid ?? false) || (isSubmitLoading ?? false)}
+            disabled={
+              (isFormInvalid ?? false) ||
+              (isSubmitLoading ?? false) ||
+              (isSubmitDisabled ?? false)
+            }
           >
             Save
             {isSubmitLoading === true ? (

--- a/frontend/src/components/Meetups/MeetupDetailsSettingsCard.tsx
+++ b/frontend/src/components/Meetups/MeetupDetailsSettingsCard.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useBoolean } from '@/hooks/useBoolean';
+import { usePendingUploads } from '@/hooks/usePendingUploads';
 import { useAppSelector } from '@/store/hooks';
 import { type EditMeetupPayload } from '@keebmeet/shared';
 import dayjs from 'dayjs';
@@ -36,6 +37,7 @@ const MeetupDetailsSettingsCard = ({ meetupId }: Props): ReactNode => {
   const currentUserId = useAppSelector((state) => state.user.user?.id);
   const [isEditable, setIsEditable] = useBoolean(false);
   const [editMeetup, { isLoading: isSaving }] = useEditMeetupMutation();
+  const { isUploading, onUploadingChange } = usePendingUploads();
   const isArchive = meetup?.is_archive === true;
   const formik = useFormik({
     initialValues: {
@@ -149,6 +151,7 @@ const MeetupDetailsSettingsCard = ({ meetupId }: Props): ReactNode => {
       onEditSubmit={onSubmit}
       isSubmitLoading={isSaving}
       isFormInvalid={false}
+      isSubmitDisabled={isUploading}
     >
       <form onSubmit={formik.handleSubmit} noValidate>
         {isArchive ? (
@@ -314,6 +317,7 @@ const MeetupDetailsSettingsCard = ({ meetupId }: Props): ReactNode => {
         <MeetupImageField
           previewUrl={formik.values.imageUrl}
           editable={isEditable}
+          onUploadingChange={onUploadingChange}
           onUploaded={(imageKey, imageUrl) => {
             void formik.setFieldValue('imageKey', imageKey);
             void formik.setFieldValue('imageUrl', imageUrl);

--- a/frontend/src/components/Meetups/MeetupDisplaySettingsCard.tsx
+++ b/frontend/src/components/Meetups/MeetupDisplaySettingsCard.tsx
@@ -2,6 +2,7 @@ import { AspectRatio } from '@/components/ui/aspect-ratio';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { useBoolean } from '@/hooks/useBoolean';
+import { usePendingUploads } from '@/hooks/usePendingUploads';
 import { useEffect, useState, type ReactNode } from 'react';
 import { FiArrowLeft, FiArrowRight, FiPlus, FiTrash2 } from 'react-icons/fi';
 import {
@@ -23,6 +24,7 @@ const MeetupDisplaySettingsCard = ({ meetupId }: Props): ReactNode => {
   const { data: displayAssets, isLoading } =
     useGetMeetupDisplayAssetsQuery(meetupId);
   const [updateMeetup, { isLoading: isSaving }] = useEditMeetupMutation();
+  const { isUploading, onUploadingChange } = usePendingUploads();
   const [isEditable, setIsEditable] = useBoolean(false);
   const [urls, setUrls] = useState<string[]>([]);
   const [raffleBackgroundUrl, setRaffleBackgroundUrl] = useState<string>('');
@@ -115,6 +117,7 @@ const MeetupDisplaySettingsCard = ({ meetupId }: Props): ReactNode => {
       onEditSubmit={onSubmit}
       isSubmitLoading={isSaving}
       isFormInvalid={false}
+      isSubmitDisabled={isUploading}
     >
       {isLoading ? (
         <div className="flex h-48 items-center justify-center">
@@ -137,6 +140,7 @@ const MeetupDisplaySettingsCard = ({ meetupId }: Props): ReactNode => {
                   onUploaded={(_imageKey, imageUrl) =>
                     setIdleUrl(index, imageUrl)
                   }
+                  onUploadingChange={onUploadingChange}
                   footer={
                     <>
                       <Button
@@ -205,6 +209,7 @@ const MeetupDisplaySettingsCard = ({ meetupId }: Props): ReactNode => {
                   onUploaded={(_imageKey, imageUrl) =>
                     setRaffleBackgroundUrl(imageUrl)
                   }
+                  onUploadingChange={onUploadingChange}
                   onRemove={() => setRaffleBackgroundUrl('')}
                 />
               </div>
@@ -225,6 +230,7 @@ const MeetupDisplaySettingsCard = ({ meetupId }: Props): ReactNode => {
                   onUploaded={(_imageKey, imageUrl) =>
                     setBatchRaffleBackgroundUrl(imageUrl)
                   }
+                  onUploadingChange={onUploadingChange}
                   onRemove={() => setBatchRaffleBackgroundUrl('')}
                 />
               </div>

--- a/frontend/src/components/Meetups/MeetupImageField.tsx
+++ b/frontend/src/components/Meetups/MeetupImageField.tsx
@@ -5,6 +5,7 @@ import { useMeetupImageUpload } from './useMeetupImageUpload';
 interface Props {
   previewUrl: string;
   onUploaded: (imageKey: string, imageUrl: string) => void;
+  onUploadingChange?: (isUploading: boolean) => void;
   onRemove?: () => void;
   editable?: boolean;
   label?: string;

--- a/frontend/src/components/shared/ImageUploadField.tsx
+++ b/frontend/src/components/shared/ImageUploadField.tsx
@@ -21,6 +21,12 @@ interface Props {
   /** Called with the R2 object key (and its public URL) after a successful upload. */
   onUploaded: (imageKey: string, imageUrl: string) => void;
   /**
+   * Called with true when an upload starts and false when it settles (or the
+   * field unmounts mid-upload). Wire to usePendingUploads so the parent form
+   * can block submission while an upload is in flight.
+   */
+  onUploadingChange?: (isUploading: boolean) => void;
+  /**
    * Called when the user clears the current image. When provided, a "Remove"
    * button is shown while editing and an image is present.
    */
@@ -53,6 +59,7 @@ interface Props {
 const ImageUploadField = ({
   previewUrl,
   onUploaded,
+  onUploadingChange,
   onRemove,
   editable = true,
   label,
@@ -64,6 +71,12 @@ const ImageUploadField = ({
   previewWidth,
 }: Props): ReactNode => {
   const { upload, isUploading } = useUpload();
+  useEffect(() => {
+    if (!isUploading) return;
+    onUploadingChange?.(true);
+    // The cleanup also reports settled if the field unmounts mid-upload.
+    return () => onUploadingChange?.(false);
+  }, [isUploading, onUploadingChange]);
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isTouch, setIsTouch] = useState(false);

--- a/frontend/src/hooks/usePendingUploads.ts
+++ b/frontend/src/hooks/usePendingUploads.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Tracks whether any image upload is still in flight so forms can block
+ * submission until it settles. Pass `onUploadingChange` to each
+ * ImageUploadField and gate the submit button on `isUploading`. Counts
+ * starts/finishes so multiple fields can upload concurrently.
+ */
+export const usePendingUploads = (): {
+  isUploading: boolean;
+  onUploadingChange: (isUploading: boolean) => void;
+} => {
+  const [pendingCount, setPendingCount] = useState(0);
+
+  const onUploadingChange = useCallback((isUploading: boolean) => {
+    setPendingCount((count) => count + (isUploading ? 1 : -1));
+  }, []);
+
+  return { isUploading: pendingCount > 0, onUploadingChange };
+};

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -10,6 +10,7 @@ import Page from '../components/Page/Page';
 import BackButton from '../components/shared/BackButton';
 import ImageUploadField from '../components/shared/ImageUploadField';
 import config from '../config';
+import { usePendingUploads } from '../hooks/usePendingUploads';
 import { useUserPhotoUpload } from '../hooks/useUserPhotoUpload';
 import { updateProfile } from '../store/authSlice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -47,6 +48,7 @@ const AccountPage = (): ReactNode => {
   });
   const [requestOrganizer, { isLoading: isRequestingOrganizer }] =
     useRequestOrganizerMutation();
+  const { isUploading, onUploadingChange } = usePendingUploads();
 
   const onRequestOrganizer = (): void => {
     void (async () => {
@@ -149,6 +151,7 @@ const AccountPage = (): ReactNode => {
                     void formik.setFieldValue('photoKey', imageKey);
                     void formik.setFieldValue('photoUrl', imageUrl);
                   }}
+                  onUploadingChange={onUploadingChange}
                   onRemove={() => {
                     void formik.setFieldValue('photoKey', '');
                     void formik.setFieldValue('photoUrl', '');
@@ -199,7 +202,9 @@ const AccountPage = (): ReactNode => {
               </div>
               <Button
                 type="submit"
-                disabled={loading || !formik.isValid || !formik.dirty}
+                disabled={
+                  loading || !formik.isValid || !formik.dirty || isUploading
+                }
                 size="lg"
               >
                 Save changes

--- a/frontend/src/pages/NewArchiveMeetupPage.tsx
+++ b/frontend/src/pages/NewArchiveMeetupPage.tsx
@@ -18,11 +18,13 @@ import { toast } from 'sonner';
 import MeetupImageField from '../components/Meetups/MeetupImageField';
 import Page from '../components/Page/Page';
 import BackButton from '../components/shared/BackButton';
+import { usePendingUploads } from '../hooks/usePendingUploads';
 import { useCreateArchiveMeetupMutation } from '../store/meetupSlice';
 import ArchiveMeetupFormSchema from '../util/schemas/ArchiveMeetupFormSchema';
 
 const NewArchiveMeetupPage = (): ReactNode => {
   const [createArchiveMeetup, { isLoading }] = useCreateArchiveMeetupMutation();
+  const { isUploading, onUploadingChange } = usePendingUploads();
   const navigate = useNavigate();
   const formik = useFormik({
     initialValues: {
@@ -139,6 +141,7 @@ const NewArchiveMeetupPage = (): ReactNode => {
                     void formik.setFieldValue('imageKey', imageKey);
                     void formik.setFieldValue('imageUrl', imageUrl);
                   }}
+                  onUploadingChange={onUploadingChange}
                 />
 
                 <Field>
@@ -164,7 +167,7 @@ const NewArchiveMeetupPage = (): ReactNode => {
 
                 <Button
                   type="submit"
-                  disabled={!formik.isValid || isLoading}
+                  disabled={!formik.isValid || isLoading || isUploading}
                   size="lg"
                 >
                   Archive

--- a/frontend/src/pages/NewMeetupPage.tsx
+++ b/frontend/src/pages/NewMeetupPage.tsx
@@ -15,11 +15,13 @@ import MeetupImageField from '../components/Meetups/MeetupImageField';
 import OrganizerCombobox from '../components/Meetups/OrganizerCombobox';
 import Page from '../components/Page/Page';
 import BackButton from '../components/shared/BackButton';
+import { usePendingUploads } from '../hooks/usePendingUploads';
 import { useCreateMeetupMutation } from '../store/meetupSlice';
 import MeetupFormSchema from '../util/schemas/MeetupFormSchema';
 
 const NewMeetupPage = (): ReactNode => {
   const [createMeetup, { isLoading }] = useCreateMeetupMutation();
+  const { isUploading, onUploadingChange } = usePendingUploads();
   const currentUserId = useAppSelector((state) => state.user.user?.id);
   const navigate = useNavigate();
   const formik = useFormik({
@@ -161,6 +163,7 @@ const NewMeetupPage = (): ReactNode => {
                     void formik.setFieldValue('imageKey', imageKey);
                     void formik.setFieldValue('imageUrl', imageUrl);
                   }}
+                  onUploadingChange={onUploadingChange}
                 />
 
                 <Field>
@@ -210,7 +213,7 @@ const NewMeetupPage = (): ReactNode => {
 
                 <Button
                   type="submit"
-                  disabled={!formik.isValid || isLoading}
+                  disabled={!formik.isValid || isLoading || isUploading}
                   size="lg"
                 >
                   Create

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -12,6 +12,7 @@ import * as Yup from 'yup';
 import { DiscordLoginButton } from '../components/Auth/DiscordLoginButton';
 import Page from '../components/Page/Page';
 import ImageUploadField from '../components/shared/ImageUploadField';
+import { usePendingUploads } from '../hooks/usePendingUploads';
 import { useUserPhotoUpload } from '../hooks/useUserPhotoUpload';
 import { register } from '../store/authSlice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
@@ -44,6 +45,7 @@ const RegisterPage = (): ReactNode => {
   const { loading, error } = useAppSelector((state) => state.user);
   const navigate = useNavigate();
   const turnstileRef = useRef<TurnstileInstance>(null);
+  const { isUploading, onUploadingChange } = usePendingUploads();
   const formik = useFormik({
     initialValues: {
       email: '',
@@ -106,6 +108,7 @@ const RegisterPage = (): ReactNode => {
                       void formik.setFieldValue('profilePhotoKey', imageKey);
                       void formik.setFieldValue('profilePhotoUrl', imageUrl);
                     }}
+                    onUploadingChange={onUploadingChange}
                     onRemove={() => {
                       void formik.setFieldValue('profilePhotoKey', '');
                       void formik.setFieldValue('profilePhotoUrl', '');
@@ -187,7 +190,7 @@ const RegisterPage = (): ReactNode => {
                 <div className="flex flex-col gap-10 pt-2">
                   <Button
                     type="submit"
-                    disabled={loading || !formik.isValid}
+                    disabled={loading || !formik.isValid || isUploading}
                     size="lg"
                   >
                     Sign up


### PR DESCRIPTION
Users will see the save button and click it while something is still uploading, and then their upload will get lost.