### PR TITLE
Add ability to transfer meetups to another organizer

### DIFF
--- a/backend/src/controllers/meetups.test.ts
+++ b/backend/src/controllers/meetups.test.ts
@@ -69,6 +69,7 @@ jest.mock('../datasource', () => {
     relation: jest.fn().mockReturnThis(),
     of: jest.fn().mockReturnThis(),
     addAndRemove: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn().mockResolvedValue(undefined),
   };
   return {
     AppDataSource: {
@@ -94,6 +95,7 @@ jest.mock('../datasource', () => {
 jest.mock('../entity/User', () => ({
   User: {
     findBy: jest.fn(),
+    findOneBy: jest.fn(),
   },
 }));
 // Keep the real pure helpers (isManagedKey/publicUrl); stub the calls that hit R2.
@@ -126,6 +128,7 @@ import {
   getMeetupAttendees,
   getMeetupDisplayAssets,
   syncEventbriteAttendees,
+  transferMeetup,
   updateMeetup,
   uploadMeetupImage,
 } from './meetups';
@@ -158,6 +161,7 @@ const mockedDataSource = jest.mocked(AppDataSource);
 // The shared relation builder returned by createQueryBuilder (see the mock).
 const organizerRelation = mockedDataSource.createQueryBuilder() as unknown as {
   addAndRemove: jest.Mock;
+  remove: jest.Mock;
 };
 const mockedRefresh = jest.mocked(refreshMeetupDiscordMessage);
 const mockedDeleteObject = jest.mocked(deleteObject);
@@ -1257,6 +1261,137 @@ describe('deleteMeetup', () => {
     expect(res.statusCode).toBe(403);
     // Nothing is destroyed for a forbidden request.
     expect(meetup.remove).not.toHaveBeenCalled();
+  });
+});
+
+// ---- transferMeetup --------------------------------------------------------
+
+describe('transferMeetup', () => {
+  it('returns 400 for an invalid body', async () => {
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' };
+
+    await transferMeetup(mockRequest({}, { meetup_id: '10' }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockedMeetup.findOne).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the meetup does not exist', async () => {
+    mockedMeetup.findOne.mockResolvedValueOnce(null);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' };
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '99' }),
+      res
+    );
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('rejects a non-lead organizer with 403', async () => {
+    const meetup = fakeMeetupRow({
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    const res = mockResponse();
+    res.locals.requestor = { id: '2' }; // a co-organizer, not the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '3' }, { meetup_id: '10' }),
+      res
+    );
+
+    expect(res.statusCode).toBe(403);
+    // Nothing is mutated for a forbidden request.
+    expect(meetup.save).not.toHaveBeenCalled();
+    expect(mockedUser.findOneBy).not.toHaveBeenCalled();
+    expect(organizerRelation.remove).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when transferring to yourself', async () => {
+    const meetup = fakeMeetupRow({
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '1' }, { meetup_id: '10' }),
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(meetup.save).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the target user does not exist', async () => {
+    const meetup = fakeMeetupRow({
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    mockedUser.findOneBy.mockResolvedValueOnce(null as never);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '10' }),
+      res
+    );
+
+    expect(res.statusCode).toBe(404);
+    expect(meetup.save).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the target user is not an organizer', async () => {
+    const meetup = fakeMeetupRow({
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    mockedUser.findOneBy.mockResolvedValueOnce({
+      id: '2',
+      nick_name: 'john',
+      is_organizer: false,
+    } as never);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '10' }),
+      res
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(meetup.save).not.toHaveBeenCalled();
+  });
+
+  it('replaces the lead organizer and drops the new lead from co-organizers', async () => {
+    const newLead = { id: '2', nick_name: 'john', is_organizer: true };
+    const meetup = fakeMeetupRow({
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    mockedUser.findOneBy.mockResolvedValueOnce(newLead as never);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '10' }),
+      res
+    );
+
+    // The lead is replaced entirely by the new organizer.
+    expect(meetup.lead_organizer).toBe(newLead);
+    expect(meetup.save).toHaveBeenCalled();
+    // The new lead must never also appear in the co-organizer join table.
+    expect(organizerRelation.remove).toHaveBeenCalledWith('2');
+    expect(mockedSocket.emit).toHaveBeenCalledWith('meetup:update', {
+      meetupId: '10',
+    });
+    expect(mockedRefresh).toHaveBeenCalledWith('10');
+    expect(res.statusCode).toBe(200);
   });
 });
 

--- a/backend/src/controllers/meetups.test.ts
+++ b/backend/src/controllers/meetups.test.ts
@@ -1312,7 +1312,7 @@ describe('transferMeetup', () => {
     // Nothing is mutated for a forbidden request.
     expect(meetup.save).not.toHaveBeenCalled();
     expect(mockedUser.findOneBy).not.toHaveBeenCalled();
-    expect(organizerRelation.remove).not.toHaveBeenCalled();
+    expect(organizerRelation.addAndRemove).not.toHaveBeenCalled();
   });
 
   it('returns 400 when transferring to yourself', async () => {
@@ -1372,7 +1372,7 @@ describe('transferMeetup', () => {
     expect(meetup.save).not.toHaveBeenCalled();
   });
 
-  it('replaces the lead organizer and drops the new lead from co-organizers', async () => {
+  it('demotes the previous lead to co-organizer and drops the new lead (live meetup)', async () => {
     const newLead = { id: '2', nick_name: 'john', is_organizer: true };
     const meetup = fakeMeetupRow({
       save: jest.fn().mockResolvedValue(undefined),
@@ -1390,14 +1390,42 @@ describe('transferMeetup', () => {
     // The lead is replaced entirely by the new organizer.
     expect(meetup.lead_organizer).toBe(newLead);
     expect(meetup.save).toHaveBeenCalled();
-    // The new lead must never also appear in the co-organizer join table.
-    expect(organizerRelation.remove).toHaveBeenCalledWith('2');
+    // The previous lead (1) is demoted to a co-organizer so they keep access;
+    // the new lead (2) is dropped (the lead is tracked separately).
+    expect(organizerRelation.addAndRemove).toHaveBeenCalledWith(['1'], ['2']);
     expect(mockedSocket.emit).toHaveBeenCalledWith('meetup:update', {
       meetupId: '10',
     });
     expect(mockedRefresh).toHaveBeenCalledWith('10');
     // The new lead is unverified, so no notification email is sent.
     expect(mockedSendTransferEmail).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('does not demote the previous lead for an archive (clean handoff)', async () => {
+    const newLead = { id: '2', nick_name: 'john', is_organizer: true };
+    const meetup = fakeMeetupRow({
+      is_archive: true,
+      // A free-text credit for whoever ran the archived meetup.
+      organizer_name: 'John Doe',
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    mockedUser.findOneBy.mockResolvedValueOnce(newLead as never);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '10' }),
+      res
+    );
+
+    expect(meetup.lead_organizer).toBe(newLead);
+    // The free-text credit is cleared so it falls back to the new lead's name.
+    expect(meetup.organizer_name).toBeNull();
+    // Archives have no co-organizer concept: the previous lead is NOT demoted,
+    // only the new lead is (defensively) removed from the join table.
+    expect(organizerRelation.addAndRemove).toHaveBeenCalledWith([], ['2']);
     expect(res.statusCode).toBe(200);
   });
 

--- a/backend/src/controllers/meetups.test.ts
+++ b/backend/src/controllers/meetups.test.ts
@@ -57,6 +57,9 @@ jest.mock('./tickets', () => ({
 jest.mock('../util/meetupDiscordMessage', () => ({
   refreshMeetupDiscordMessage: jest.fn(),
 }));
+jest.mock('../util/email', () => ({
+  sendMeetupTransferredEmail: jest.fn(),
+}));
 // The added-organizer email side effect is covered separately in
 // organizerAddedNotification.test.ts; here we only stub it out.
 jest.mock('../util/organizerAddedNotification', () => ({
@@ -152,6 +155,7 @@ import {
 import { geocode, getUtcOffset } from '../util/externalApis';
 import { syncEventbriteAttendee } from './tickets';
 import { refreshMeetupDiscordMessage } from '../util/meetupDiscordMessage';
+import { sendMeetupTransferredEmail } from '../util/email';
 import { deleteObject, promoteImage, upload } from '../util/objectStorage';
 import { normalizeImage } from '../util/imageProcessing';
 
@@ -164,6 +168,7 @@ const organizerRelation = mockedDataSource.createQueryBuilder() as unknown as {
   remove: jest.Mock;
 };
 const mockedRefresh = jest.mocked(refreshMeetupDiscordMessage);
+const mockedSendTransferEmail = jest.mocked(sendMeetupTransferredEmail);
 const mockedDeleteObject = jest.mocked(deleteObject);
 const mockedPromoteImage = jest.mocked(promoteImage);
 const mockedUpload = jest.mocked(upload);
@@ -1391,7 +1396,70 @@ describe('transferMeetup', () => {
       meetupId: '10',
     });
     expect(mockedRefresh).toHaveBeenCalledWith('10');
+    // The new lead is unverified, so no notification email is sent.
+    expect(mockedSendTransferEmail).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
+  });
+
+  it('emails the new lead organizer when they are verified', async () => {
+    const newLead = {
+      id: '2',
+      nick_name: 'john',
+      email: 'john@example.com',
+      is_organizer: true,
+      is_verified: true,
+    };
+    const meetup = fakeMeetupRow({
+      name: 'Tex Mechs',
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    mockedUser.findOneBy.mockResolvedValueOnce(newLead as never);
+    const res = mockResponse();
+    res.locals.requestor = { id: '1', nick_name: 'jane' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '10' }),
+      res
+    );
+
+    // New lead's email, meetup name, previous lead's name, and a manage link.
+    expect(mockedSendTransferEmail).toHaveBeenCalledWith(
+      'john@example.com',
+      'Tex Mechs',
+      'jane',
+      expect.stringContaining('/meetup/10/manage')
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('still succeeds if the notification email fails', async () => {
+    const newLead = {
+      id: '2',
+      nick_name: 'john',
+      email: 'john@example.com',
+      is_organizer: true,
+      is_verified: true,
+    };
+    const meetup = fakeMeetupRow({
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+    mockedMeetup.findOne.mockResolvedValueOnce(meetup);
+    mockedUser.findOneBy.mockResolvedValueOnce(newLead as never);
+    mockedSendTransferEmail.mockRejectedValueOnce(new Error('resend down'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = mockResponse();
+    res.locals.requestor = { id: '1', nick_name: 'jane' }; // the lead
+
+    await transferMeetup(
+      mockRequest({ new_lead_organizer_id: '2' }, { meetup_id: '10' }),
+      res
+    );
+
+    // The transfer is already committed, so a mail failure must not fail it.
+    expect(meetup.save).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    errorSpy.mockRestore();
   });
 });
 

--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -3,6 +3,7 @@ import {
   createMeetupFromEventbriteSchema,
   createMeetupSchema,
   editMeetupSchema,
+  transferMeetupSchema,
   type EditMeetupPayload,
   type MeetupDisplayAssets,
   type MeetupInfo,
@@ -863,6 +864,71 @@ export const updateMeetup = async (
   socket.emit('meetup:update', { meetupId: meetup.id });
   await refreshMeetupDiscordMessage(meetup.id);
   return res.status(201).json(meetup);
+};
+
+export const transferMeetup = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { meetup_id } = req.params as Record<string, string>;
+
+  const result = transferMeetupSchema.safeParse(req.body);
+  if (!result.success) {
+    return res.status(400).json(result.error);
+  }
+
+  const meetup = await Meetup.findOne({
+    relations: {
+      lead_organizer: true,
+    },
+    where: { id: meetup_id },
+  });
+
+  if (meetup == null) {
+    return res.status(404).json({ message: 'Invalid meetup ID.' });
+  }
+
+  // Verify requestor is lead organizer (authChecker only checks organizer)
+  const requestor = res.locals.requestor as User;
+  if (meetup.lead_organizer?.id !== requestor.id) {
+    return res.status(403).json({
+      message: 'Only the lead organizer can transfer this meetup.',
+    });
+  }
+
+  const newLeadId = result.data.new_lead_organizer_id;
+
+  if (newLeadId === requestor.id) {
+    return res
+      .status(400)
+      .json({ message: 'You are already the lead organizer.' });
+  }
+
+  const newLead = await User.findOneBy({ id: newLeadId });
+  if (newLead == null) {
+    return res.status(404).json({ message: 'Invalid user ID.' });
+  }
+
+  // The new lead must be an organizer, same as any meetup owner.
+  if (!newLead.is_organizer) {
+    return res
+      .status(400)
+      .json({ message: 'The new lead organizer must be an organizer.' });
+  }
+
+  meetup.lead_organizer = newLead;
+  await meetup.save();
+
+  // Remove new lead from organizer list if previously added as a co-organizer
+  await AppDataSource.createQueryBuilder()
+    .relation(Meetup, 'organizers')
+    .of(meetup.id)
+    .remove(newLeadId);
+
+  socket.emit('meetup:update', { meetupId: meetup.id });
+  await refreshMeetupDiscordMessage(meetup.id);
+
+  return res.status(200).json(meetup);
 };
 
 export const deleteMeetup = async (

--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -31,6 +31,7 @@ import { RaffleWinner } from '../entity/RaffleWinner';
 import { Ticket } from '../entity/Ticket';
 import { User } from '../entity/User';
 import { deleteEmbedMessage } from '../util/discord';
+import { sendMeetupTransferredEmail } from '../util/email';
 import {
   createEventbriteWebhook,
   deleteEventbriteWebhook,
@@ -44,7 +45,6 @@ import {
   getUtcOffset,
   type GeocodeResults,
 } from '../util/externalApis';
-import { sendMeetupTransferredEmail } from '../util/email';
 import { deleteManagedObjects } from '../util/imageCleanup';
 import { normalizeImage } from '../util/imageProcessing';
 import { refreshMeetupDiscordMessage } from '../util/meetupDiscordMessage';
@@ -917,14 +917,27 @@ export const transferMeetup = async (
       .json({ message: 'The new lead organizer must be an organizer.' });
   }
 
+  const previousLead = meetup.lead_organizer;
+
   meetup.lead_organizer = newLead;
+
+  // Assume that a transferred archive meetup was organized by the new lead so
+  // clear the display credit
+  if (meetup.is_archive) {
+    meetup.organizer_name = null;
+  }
+
   await meetup.save();
 
   // Remove new lead from organizer list if previously added as a co-organizer
+  // and demote previous lead to co-organizer (only if not an archive meetup -
+  // previous lead loses all access)
+  const demotedLeadIds =
+    !meetup.is_archive && previousLead != null ? [previousLead.id] : [];
   await AppDataSource.createQueryBuilder()
     .relation(Meetup, 'organizers')
     .of(meetup.id)
-    .remove(newLeadId);
+    .addAndRemove(demotedLeadIds, [newLeadId]);
 
   socket.emit('meetup:update', { meetupId: meetup.id });
   await refreshMeetupDiscordMessage(meetup.id);

--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -44,6 +44,7 @@ import {
   getUtcOffset,
   type GeocodeResults,
 } from '../util/externalApis';
+import { sendMeetupTransferredEmail } from '../util/email';
 import { deleteManagedObjects } from '../util/imageCleanup';
 import { normalizeImage } from '../util/imageProcessing';
 import { refreshMeetupDiscordMessage } from '../util/meetupDiscordMessage';
@@ -927,6 +928,21 @@ export const transferMeetup = async (
 
   socket.emit('meetup:update', { meetupId: meetup.id });
   await refreshMeetupDiscordMessage(meetup.id);
+
+  // Notify the new lead organizer by email (verified users only). Best-effort:
+  // a mail failure must not fail the transfer, which is already committed.
+  if (newLead.is_verified) {
+    try {
+      await sendMeetupTransferredEmail(
+        newLead.email,
+        meetup.name,
+        requestor.nick_name,
+        `${config.webUrl}/meetup/${meetup.id}/manage`
+      );
+    } catch (error) {
+      console.error('Failed to send meetup transferred email:', error);
+    }
+  }
 
   return res.status(200).json(meetup);
 };

--- a/backend/src/routes/meetups.ts
+++ b/backend/src/routes/meetups.ts
@@ -15,6 +15,7 @@ import {
   getMeetupAttendees,
   getMeetupDisplayAssets,
   syncEventbriteAttendees,
+  transferMeetup,
   updateMeetup,
   uploadMeetupImage,
 } from '../controllers/meetups';
@@ -72,6 +73,12 @@ router.delete(
   '/:meetup_id',
   authChecker([Rule.requireOrganizer]) as RequestHandler,
   deleteMeetup as RequestHandler
+);
+
+router.post(
+  '/:meetup_id/transfer',
+  authChecker([Rule.requireOrganizer]) as RequestHandler,
+  transferMeetup as RequestHandler
 );
 
 router.post(

--- a/backend/src/util/email.ts
+++ b/backend/src/util/email.ts
@@ -1,4 +1,5 @@
 import {
+  MeetupTransferredEmail,
   OrganizerAddedEmail,
   OrganizerApprovedEmail,
   OrganizerDeniedEmail,
@@ -96,6 +97,24 @@ export const sendOrganizerAddedEmail = async (
     to: [email],
     subject: `You've been added as an organizer for ${meetupName}`,
     react: OrganizerAddedEmail({ meetupName, leadOrganizerName, manageLink }),
+  });
+
+  if (error) {
+    console.error('Error sending email:', error);
+  }
+};
+
+export const sendMeetupTransferredEmail = async (
+  email: string,
+  meetupName: string,
+  previousLeadName: string,
+  manageLink: string
+) => {
+  const { error } = await getResendClient().emails.send({
+    from: 'KeebMeet <noreply@keebmeet.com>',
+    to: [email],
+    subject: `You're now the lead organizer for ${meetupName}`,
+    react: MeetupTransferredEmail({ meetupName, previousLeadName, manageLink }),
   });
 
   if (error) {

--- a/emails/emails/meetup-transferred-email.tsx
+++ b/emails/emails/meetup-transferred-email.tsx
@@ -1,0 +1,39 @@
+import { Button, Heading, Text } from '@react-email/components';
+import { EmailLayout } from '../components/EmailLayout';
+
+export interface MeetupTransferredEmailProps {
+  meetupName: string;
+  previousLeadName: string;
+  manageLink: string;
+}
+
+export const MeetupTransferredEmail = ({
+  meetupName,
+  previousLeadName,
+  manageLink,
+}: MeetupTransferredEmailProps) => (
+  <EmailLayout preview={`You're now the lead organizer for ${meetupName}`}>
+    <Heading className="m-0 mb-4 text-[22px] font-semibold text-foreground">
+      You&apos;re now the lead organizer
+    </Heading>
+    <Text className="m-0 mb-6 text-[15px] leading-6 text-foreground">
+      {previousLeadName} transferred <strong>{meetupName}</strong> to you. You
+      now have full control of the meetup, including its attendees, raffles, and
+      settings.
+    </Text>
+    <Button
+      className="rounded-md bg-primary px-5 py-3 text-[15px] font-semibold text-primary-foreground"
+      href={manageLink}
+    >
+      Manage the meetup
+    </Button>
+  </EmailLayout>
+);
+
+MeetupTransferredEmail.PreviewProps = {
+  meetupName: 'Tex Mechs Spring Meetup',
+  previousLeadName: 'Grace Hopper',
+  manageLink: 'https://keebmeet.com/meetups/1/manage',
+} satisfies MeetupTransferredEmailProps;
+
+export default MeetupTransferredEmail;

--- a/emails/index.ts
+++ b/emails/index.ts
@@ -12,5 +12,8 @@ export { OrganizerDeniedEmail } from './emails/organizer-denied-email';
 export { OrganizerAddedEmail } from './emails/organizer-added-email';
 export type { OrganizerAddedEmailProps } from './emails/organizer-added-email';
 
+export { MeetupTransferredEmail } from './emails/meetup-transferred-email';
+export type { MeetupTransferredEmailProps } from './emails/meetup-transferred-email';
+
 export { RsvpConfirmationEmail } from './emails/rsvp-confirmation-email';
 export type { RsvpConfirmationEmailProps } from './emails/rsvp-confirmation-email';

--- a/frontend/src/components/Meetups/DangerZoneCard.tsx
+++ b/frontend/src/components/Meetups/DangerZoneCard.tsx
@@ -25,7 +25,7 @@ interface Props {
   meetupId: string;
 }
 
-export const DeleteMeetupCard = ({ meetupId }: Props): ReactNode => {
+export const DangerZoneCard = ({ meetupId }: Props): ReactNode => {
   const navigate = useNavigate();
   const { data: meetup } = useGetMeetupQuery(meetupId);
   const [deleteMeetup, { isLoading: isDeleting }] = useDeleteMeetupMutation();
@@ -117,4 +117,4 @@ export const DeleteMeetupCard = ({ meetupId }: Props): ReactNode => {
   );
 };
 
-export default DeleteMeetupCard;
+export default DangerZoneCard;

--- a/frontend/src/components/Meetups/DangerZoneCard.tsx
+++ b/frontend/src/components/Meetups/DangerZoneCard.tsx
@@ -139,6 +139,25 @@ export const DangerZoneCard = ({ meetupId }: Props): ReactNode => {
               gains full control of the meetup and this action cannot be undone.
             </DialogDescription>
           </DialogHeader>
+          {meetup?.is_archive ? (
+            <p className="text-muted-foreground text-sm">
+              Since this is an archived meetup, the new lead organizer will be
+              credited as its organizer
+              {meetup.organizer_name != null ? (
+                <>
+                  , replacing{' '}
+                  <span className="font-bold">{meetup.organizer_name}</span>
+                </>
+              ) : null}
+              , and <span className="font-bold">you will lose all access</span>{' '}
+              to it.
+            </p>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              You&apos;ll remain an organizer with access to manage this meetup
+              — you just won&apos;t be the lead organizer.
+            </p>
+          )}
           <Field>
             <FieldLabel htmlFor="transfer-organizer">
               New lead organizer

--- a/frontend/src/components/Meetups/DangerZoneCard.tsx
+++ b/frontend/src/components/Meetups/DangerZoneCard.tsx
@@ -10,16 +10,20 @@ import {
 } from '@/components/ui/dialog';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 import { Spinner } from '@/components/ui/spinner';
 import {
   useDeleteMeetupMutation,
   useGetMeetupQuery,
+  useTransferMeetupMutation,
 } from '@/store/meetupSlice';
+import { useGetOrganizersQuery } from '@/store/userSlice';
 import { ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
+import OrganizerSelect from './OrganizerSelect';
 
 interface Props {
   meetupId: string;
@@ -28,15 +32,41 @@ interface Props {
 export const DangerZoneCard = ({ meetupId }: Props): ReactNode => {
   const navigate = useNavigate();
   const { data: meetup } = useGetMeetupQuery(meetupId);
+  const { data: organizers } = useGetOrganizersQuery();
   const [deleteMeetup, { isLoading: isDeleting }] = useDeleteMeetupMutation();
+  const [transferMeetup, { isLoading: isTransferring }] =
+    useTransferMeetupMutation();
 
   const [open, setOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
+
+  const [transferOpen, setTransferOpen] = useState(false);
+  const [transferOrganizerId, setTransferOrganizerId] = useState('');
+  const [transferConfirmText, setTransferConfirmText] = useState('');
 
   // Deleting a meetup wipes all of its tickets, raffle records and wins, so we
   // require the organizer to type the meetup's name to confirm.
   const canConfirm =
     meetup != null && confirmText.trim() === meetup.name.trim();
+
+  const selectedOrganizer = (organizers ?? []).find(
+    (organizer) => organizer.id === transferOrganizerId
+  );
+
+  // Transferring is irreversible, so we require typing 'organizer/meetup' — the
+  // new lead's display name and the meetup name — to confirm.
+  const transferConfirmTarget =
+    selectedOrganizer != null && meetup != null
+      ? `${selectedOrganizer.display_name.trim()}-${meetup.name.trim()}`
+      : null;
+  const canConfirmTransfer =
+    transferConfirmTarget != null &&
+    transferConfirmText.trim() === transferConfirmTarget;
+
+  const resetTransfer = (): void => {
+    setTransferOrganizerId('');
+    setTransferConfirmText('');
+  };
 
   const onDelete = async (): Promise<void> => {
     if (!canConfirm) return;
@@ -57,9 +87,109 @@ export const DangerZoneCard = ({ meetupId }: Props): ReactNode => {
     navigate('/organizer');
   };
 
+  const onTransfer = async (): Promise<void> => {
+    if (!canConfirmTransfer || selectedOrganizer == null) return;
+
+    const result = await transferMeetup({
+      meetupId,
+      payload: { new_lead_organizer_id: selectedOrganizer.id },
+    });
+
+    if ('error' in result && result.error != null) {
+      const error = result.error as { data?: { message?: string } };
+      toast.error('Failed to transfer meetup', {
+        description: error.data?.message,
+      });
+      return;
+    }
+
+    setTransferOpen(false);
+    resetTransfer();
+    toast.success(`Meetup transferred to ${selectedOrganizer.display_name}.`);
+    // The requestor is no longer the lead organizer, so send them back to their
+    // organizer dashboard.
+    navigate('/organizer');
+  };
+
   return (
     <Card className="border-destructive gap-2 p-4">
       <h2 className="text-destructive text-2xl font-semibold">Danger zone</h2>
+
+      <p className="text-muted-foreground">
+        Transferring this meetup hands it off to another organizer, replacing
+        you as the lead organizer entirely. This action cannot be undone.
+      </p>
+      <Dialog
+        open={transferOpen}
+        onOpenChange={(next) => {
+          setTransferOpen(next);
+          if (!next) resetTransfer();
+        }}
+      >
+        <DialogTrigger asChild>
+          <Button className="self-start" variant="outline">
+            Transfer meetup
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Transfer this meetup?</DialogTitle>
+            <DialogDescription>
+              This replaces you as the lead organizer entirely. The new lead
+              gains full control of the meetup and this action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor="transfer-organizer">
+              New lead organizer
+            </FieldLabel>
+            <OrganizerSelect
+              id="transfer-organizer"
+              value={transferOrganizerId}
+              onChange={setTransferOrganizerId}
+              // Can't transfer the meetup to its current lead organizer.
+              excludeIds={
+                meetup?.lead_organizer != null ? [meetup.lead_organizer.id] : []
+              }
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="confirm-transfer">
+              Type{' '}
+              <span className="font-bold">
+                {transferConfirmTarget ?? 'organizer-meetup'}
+              </span>{' '}
+              to confirm.
+            </FieldLabel>
+            <Input
+              id="confirm-transfer"
+              value={transferConfirmText}
+              onChange={(event) => setTransferConfirmText(event.target.value)}
+              placeholder={transferConfirmTarget ?? 'organizer-meetup'}
+              autoComplete="off"
+              disabled={selectedOrganizer == null}
+            />
+          </Field>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="secondary">Cancel</Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                void onTransfer();
+              }}
+              disabled={!canConfirmTransfer || isTransferring}
+            >
+              Transfer meetup
+              {isTransferring && <Spinner />}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Separator className="my-2" />
+
       <p className="text-muted-foreground">
         Deleting this meetup permanently removes it along with all of its
         tickets, raffle records, and raffle wins. This action cannot be undone.

--- a/frontend/src/components/Meetups/OrganizerSelect.tsx
+++ b/frontend/src/components/Meetups/OrganizerSelect.tsx
@@ -1,0 +1,65 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useGetOrganizersQuery } from '@/store/userSlice';
+import { type ReactNode } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (organizerId: string) => void;
+  excludeIds?: string[];
+  disabled?: boolean;
+  id?: string;
+  placeholder?: string;
+}
+
+/**
+ * Single-select dropdown for picking a single meetup organizer, showing each
+ * organizer's profile picture alongside their display name. Complements the
+ * multi-select OrganizerCombobox for flows that pick exactly one organizer.
+ */
+const OrganizerSelect = ({
+  value,
+  onChange,
+  excludeIds = [],
+  disabled = false,
+  id,
+  placeholder = 'Select an organizer',
+}: Props): ReactNode => {
+  const { data: organizers } = useGetOrganizersQuery();
+
+  const options = (organizers ?? []).filter(
+    (organizer) => !excludeIds.includes(organizer.id)
+  );
+
+  return (
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
+      <SelectTrigger id={id} className="w-full">
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((organizer) => (
+          <SelectItem key={organizer.id} value={organizer.id}>
+            <Avatar size="sm">
+              <AvatarImage
+                src={organizer.photo_url}
+                alt={organizer.display_name}
+              />
+              <AvatarFallback>
+                {organizer.display_name[0].toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            {organizer.display_name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default OrganizerSelect;

--- a/frontend/src/pages/ManageMeetupSettingsPage.tsx
+++ b/frontend/src/pages/ManageMeetupSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { DeleteMeetupCard } from '@/components/Meetups/DeleteMeetupCard';
+import { DangerZoneCard } from '@/components/Meetups/DangerZoneCard';
 import { MeetupDiscordCard } from '@/components/Meetups/MeetupDiscordCard';
 import { MeetupEventbriteCard } from '@/components/Meetups/MeetupEventbriteCard';
 import { Spinner } from '@/components/ui/spinner';
@@ -27,7 +27,7 @@ const ManageMeetupSettingsPage = (): ReactNode => {
       <MeetupEventbriteCard meetupId={meetupId ?? ''} />
       <MeetupDiscordCard meetupId={meetupId ?? ''} />
       {meetup?.lead_organizer?.id === currentUserId && (
-        <DeleteMeetupCard meetupId={meetupId ?? ''} />
+        <DangerZoneCard meetupId={meetupId ?? ''} />
       )}
     </div>
   );

--- a/frontend/src/store/meetupSlice.ts
+++ b/frontend/src/store/meetupSlice.ts
@@ -1,13 +1,14 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import type { MeetupInfo } from '@keebmeet/shared';
-import { type MeetupDisplayAssets } from '@keebmeet/shared';
-import { type MeetupDiscordMessageInfo } from '@keebmeet/shared';
 import {
   type CreateArchiveMeetupPayload,
   type CreateMeetupFromEventbritePayload,
   type CreateMeetupPayload,
   type EditMeetupPayload,
+  type MeetupDiscordMessageInfo,
+  type MeetupDisplayAssets,
+  type TransferMeetupPayload,
 } from '@keebmeet/shared';
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import config from '../config';
 import { apiCacheDefaults } from './apiCacheDefaults';
 import { type RootState } from './store';
@@ -20,6 +21,11 @@ export interface GetMeetupsOptions {
 interface EditMeetupOptions {
   meetupId: string;
   payload: EditMeetupPayload;
+}
+
+interface TransferMeetupOptions {
+  meetupId: string;
+  payload: TransferMeetupPayload;
 }
 
 export const meetupSlice = createApi({
@@ -122,6 +128,17 @@ export const meetupSlice = createApi({
         { type: 'Meetup', id: arg },
       ],
     }),
+    transferMeetup: builder.mutation<void, TransferMeetupOptions>({
+      query: ({ meetupId, payload }) => ({
+        url: `meetups/${meetupId}/transfer`,
+        method: 'POST',
+        body: payload,
+      }),
+      invalidatesTags: (result, error, arg) => [
+        'Meetups',
+        { type: 'Meetup', id: arg.meetupId },
+      ],
+    }),
     getMeetupDisplayAssets: builder.query<MeetupDisplayAssets, string>({
       query: (meetupId) => ({
         url: `meetups/${meetupId}/display-assets`,
@@ -193,6 +210,7 @@ export const {
   useCreateMeetupFromEventbriteMutation,
   useEditMeetupMutation,
   useDeleteMeetupMutation,
+  useTransferMeetupMutation,
   useGetMeetupDisplayAssetsQuery,
   useGetMeetupDiscordMessageQuery,
   useCreateMeetupDiscordMessageMutation,

--- a/shared/src/validation.ts
+++ b/shared/src/validation.ts
@@ -79,6 +79,12 @@ export const editMeetupSchema = z.object({
 
 export type EditMeetupPayload = z.infer<typeof editMeetupSchema>;
 
+export const transferMeetupSchema = z.object({
+  new_lead_organizer_id: z.string(),
+});
+
+export type TransferMeetupPayload = z.infer<typeof transferMeetupSchema>;
+
 export const createMeetupDiscordMessageSchema = z.object({
   server_id: z.string(),
   channel_id: z.string(),


### PR DESCRIPTION
This will update the lead organizer of a meetup. I wasn't sure if the previous lead organizer should be added to the co-organizer list because it gets weird with archive meetups which don't have a way to edit the organizer list... but also archive meetups are the main reason for this feature