### PR TITLE
Fix profile gallery tab appearing after some delay

### DIFF
--- a/backend/src/controllers/users.ts
+++ b/backend/src/controllers/users.ts
@@ -6,9 +6,11 @@ import {
 } from '@keebmeet/shared';
 import { type Request, type Response } from 'express';
 import { ILike } from 'typeorm';
+import { GalleryRecord } from '../entity/GalleryRecord';
 import { OrganizerRequest } from '../entity/OrganizerRequest';
 import { User } from '../entity/User';
 import { fetchDiscordUsername } from '../util/discord';
+import { getVisibleUnlistedMeetups } from '../util/meetupVisibility';
 import { normalizeImage } from '../util/imageProcessing';
 import {
   IMAGE_EXT_BY_MIME,
@@ -133,12 +135,28 @@ export const getPublicUser = async (
     return res.status(404).json({ message: 'User not found.' });
   }
 
+  const galleryRecords = await GalleryRecord.find({
+    relations: { meetup: true },
+    where: { user_id: user.id },
+  });
+
+  // Same unlisted filter as getUserGalleries.
+  const requestor = res.locals.requestor as User | undefined;
+  const visibleUnlisted = new Set(
+    (await getVisibleUnlistedMeetups(requestor)).all
+  );
+  const hasGalleries = galleryRecords.some(
+    (record) =>
+      !record.meetup.is_unlisted || visibleUnlisted.has(record.meetup.id)
+  );
+
   const response: PublicUserInterface = {
     id: user.id,
     username: user.username,
     display_name: user.nick_name,
     photo_url: publicUrl(user.photo_key ?? ''),
     is_organizer: user.is_organizer,
+    has_galleries: hasGalleries,
   };
 
   return res.json(response);

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -46,7 +46,11 @@ router.get(
   authChecker([Rule.requireOrganizer]) as RequestHandler,
   searchUsers as RequestHandler
 );
-router.get('/:user_id/public', getPublicUser as RequestHandler);
+router.get(
+  '/:user_id/public',
+  optionalAuth() as RequestHandler,
+  getPublicUser as RequestHandler
+);
 router.get(
   '/:user_id/galleries',
   optionalAuth() as RequestHandler,

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -73,9 +73,10 @@ const ProfilePage = (): ReactNode => {
   });
 
   // Galleries aren't organizer-gated.
-  const { data: galleries = [] } = useGetUserGalleriesQuery(username ?? '', {
-    skip: username == null,
-  });
+  const { data: galleries = [], isLoading: isGalleriesLoading } =
+    useGetUserGalleriesQuery(username ?? '', {
+      skip: username == null,
+    });
 
   // Editing/deleting a gallery is gated to the profile's own owner.
   const isOwnProfile = user != null && user.id === profileUser?.id;
@@ -184,7 +185,11 @@ const ProfilePage = (): ReactNode => {
     </div>
   );
 
-  const galleriesContent = (
+  const galleriesContent = isGalleriesLoading ? (
+    <div className="flex justify-center py-16">
+      <Spinner className="size-8" />
+    </div>
+  ) : (
     <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
       {galleries.map((gallery) => (
         <GalleryCard

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -216,7 +216,7 @@ const ProfilePage = (): ReactNode => {
 
   // A tab shows only when it has content; a lone tab acts as the label.
   const hasMeetups = isOrganizer && total > 0;
-  const hasGalleries = galleries.length > 0;
+  const hasGalleries = profileUser?.has_galleries === true;
 
   // The active tab lives in the URL (/user/:username/:tab) so it's shareable;
   // an unknown or missing segment falls back to the first available tab.

--- a/shared/src/userInterfaces.ts
+++ b/shared/src/userInterfaces.ts
@@ -33,6 +33,7 @@ export interface PublicUser {
   display_name: string;
   photo_url: string;
   is_organizer: boolean;
+  has_galleries?: boolean;
 }
 
 export interface OrganizerRequestInfo {


### PR DESCRIPTION
galleries took a while to load if a user has a lot because it has to fetch the previews. It waits for all of them load before showing the actual tab. so the lighter weight get user now includes if it should render the gallery tab, instead of waiting for the actual galleries.