### PR TITLE
Add "add to calendar" to modal and confirmation email

### DIFF
--- a/backend/src/controllers/meetups.ts
+++ b/backend/src/controllers/meetups.ts
@@ -35,6 +35,7 @@ import { Tag } from '../entity/Tag';
 import { Ticket } from '../entity/Ticket';
 import { TicketType } from '../entity/TicketType';
 import { User } from '../entity/User';
+import { buildMeetupIcsFromEntity } from '../util/calendar';
 import { deleteEmbedMessage } from '../util/discord';
 import { sendMeetupTransferredEmail } from '../util/email';
 import {
@@ -431,6 +432,24 @@ export const getMeetup = async (
   );
 
   return res.json(meetupInfo);
+};
+
+// Real .ics response so mobile hands it to the calendar app (a data: URI can't).
+export const getMeetupCalendar = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { meetup_id: slug } = req.params as Record<string, string>;
+
+  const meetup = await Meetup.findOne({ where: { slug } });
+
+  if (meetup == null) {
+    return res.status(404).json({ message: 'Meetup not found.' });
+  }
+
+  res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${slug}.ics"`);
+  return res.send(buildMeetupIcsFromEntity(meetup));
 };
 
 export const slugAvailable = async (

--- a/backend/src/controllers/ticketPayments.ts
+++ b/backend/src/controllers/ticketPayments.ts
@@ -11,6 +11,10 @@ import { Ticket } from '../entity/Ticket';
 import { type TicketType } from '../entity/TicketType';
 import { type User } from '../entity/User';
 import { checkMeetupOrganizer } from '../middleware/authChecker';
+import {
+  buildMeetupCalendarLinksFromEntity,
+  buildMeetupIcsFromEntity,
+} from '../util/calendar';
 import { sendRefundEmail, sendRsvpConfirmationEmail } from '../util/email';
 import {
   buildGuestCancelLink,
@@ -167,6 +171,7 @@ export const finalizeTicketSideEffects = async (
           generateGuestCancelToken(ticket.id, getMeetupEnd(meetup))
         )
       : undefined;
+  const calendarLinks = buildMeetupCalendarLinksFromEntity(meetup);
   await sendRsvpConfirmationEmail(
     ticket.ticket_holder_email,
     meetup.name,
@@ -175,6 +180,10 @@ export const finalizeTicketSideEffects = async (
       .format('dddd, MMMM D, YYYY [at] h:mm A'),
     meetup.address,
     ticket.id,
+    {
+      links: { google: calendarLinks.google, outlook: calendarLinks.outlook },
+      ics: buildMeetupIcsFromEntity(meetup),
+    },
     await buildTicketReceipt(ticket),
     cancelLink
   );

--- a/backend/src/controllers/tickets.test.ts
+++ b/backend/src/controllers/tickets.test.ts
@@ -449,6 +449,14 @@ describe('createTicket', () => {
       expect.any(String),
       '123 Main St',
       'new-ticket-id',
+      // calendar arg: links + attached .ics
+      expect.objectContaining({
+        links: expect.objectContaining({
+          google: expect.any(String),
+          outlook: expect.any(String),
+        }),
+        ics: expect.stringContaining('BEGIN:VCALENDAR'),
+      }),
       // Free RSVP: no receipt.
       undefined,
       // Every free RSVP carries a self-serve cancel link.

--- a/backend/src/routes/meetups.ts
+++ b/backend/src/routes/meetups.ts
@@ -24,6 +24,7 @@ import {
   getAllMeetups,
   getMeetup,
   getMeetupAttendees,
+  getMeetupCalendar,
   getMeetupDisplayAssets,
   slugAvailable,
   syncEventbriteAttendees,
@@ -62,6 +63,8 @@ router.get(
   optionalAuth() as RequestHandler,
   getMeetup as RequestHandler
 );
+
+router.get('/:meetup_id/calendar.ics', getMeetupCalendar as RequestHandler);
 
 router.post(
   '/',

--- a/backend/src/util/calendar.ts
+++ b/backend/src/util/calendar.ts
@@ -1,0 +1,27 @@
+import {
+  buildMeetupCalendarLinks,
+  buildMeetupIcsContent,
+  type MeetupCalendarEvent,
+  type MeetupCalendarLinks,
+} from '@keebmeet/shared';
+import dayjs from 'dayjs';
+import { Meetup } from '../entity/Meetup';
+
+// date is the absolute instant; utc_offset only affects display.
+const toCalendarEvent = (meetup: Meetup): MeetupCalendarEvent => ({
+  id: meetup.id,
+  title: meetup.name,
+  description: meetup.description || undefined,
+  location: [meetup.address, meetup.city, meetup.state, meetup.country]
+    .filter((part) => part != null && part !== '')
+    .join(', '),
+  start: dayjs(meetup.date).toDate(),
+  durationHours: meetup.duration_hours,
+});
+
+export const buildMeetupCalendarLinksFromEntity = (
+  meetup: Meetup
+): MeetupCalendarLinks => buildMeetupCalendarLinks(toCalendarEvent(meetup));
+
+export const buildMeetupIcsFromEntity = (meetup: Meetup): string =>
+  buildMeetupIcsContent(toCalendarEvent(meetup));

--- a/backend/src/util/email.ts
+++ b/backend/src/util/email.ts
@@ -165,6 +165,11 @@ export const sendRsvpConfirmationEmail = async (
   meetupDate: string,
   meetupLocation: string,
   ticketId: string,
+  calendar?: {
+    links: { google: string; outlook: string };
+    // Raw .ics, attached as a file since many clients strip data: links.
+    ics: string;
+  },
   receipt?: { amountPaid: string; receiptUrl?: string },
   cancelLink?: string
 ) => {
@@ -181,6 +186,7 @@ export const sendRsvpConfirmationEmail = async (
       amountPaid: receipt?.amountPaid,
       receiptUrl: receipt?.receiptUrl,
       cancelLink,
+      calendarLinks: calendar?.links,
     }),
     attachments: [
       {
@@ -188,6 +194,15 @@ export const sendRsvpConfirmationEmail = async (
         content: qrCode,
         contentId: 'qr-code',
       },
+      ...(calendar != null
+        ? [
+            {
+              filename: `${meetupName.replace(/[^\w\s-]/g, '').trim() || 'meetup'}.ics`,
+              content: Buffer.from(calendar.ics, 'utf-8'),
+              contentType: 'text/calendar',
+            },
+          ]
+        : []),
     ],
   });
 

--- a/emails/emails/rsvp-confirmation-email.tsx
+++ b/emails/emails/rsvp-confirmation-email.tsx
@@ -1,4 +1,4 @@
-import { Heading, Img, Link, Section, Text } from '@react-email/components';
+import { Heading, Hr, Img, Link, Section, Text } from '@react-email/components';
 import { EmailLayout } from '../components/EmailLayout';
 
 export interface RsvpConfirmationEmailProps {
@@ -14,6 +14,11 @@ export interface RsvpConfirmationEmailProps {
   qrCodeCid?: string;
   /** Self-serve cancellation link; only set for guest RSVPs. */
   cancelLink?: string;
+  // Web links only; the .ics is attached separately (clients strip data: URIs).
+  calendarLinks?: {
+    google: string;
+    outlook: string;
+  };
 }
 
 export const RsvpConfirmationEmail = ({
@@ -24,6 +29,7 @@ export const RsvpConfirmationEmail = ({
   receiptUrl,
   qrCodeCid = 'qr-code',
   cancelLink,
+  calendarLinks,
 }: RsvpConfirmationEmailProps) => (
   <EmailLayout preview={`RSVP confirmation for ${meetupName}`}>
     <Heading className="text-foreground m-0 mb-4 text-[22px] font-semibold">
@@ -52,6 +58,27 @@ export const RsvpConfirmationEmail = ({
           ) : null}
         </Text>
       ) : null}
+      {calendarLinks != null ? (
+        <>
+          <Hr className="border-border my-3 border-0 border-t border-solid" />
+          <Text className="text-foreground m-0 text-[14px] leading-6">
+            <strong>Add to calendar:</strong>{' '}
+            <Link href={calendarLinks.google} className="text-primary underline">
+              Google
+            </Link>
+            {' · '}
+            <Link
+              href={calendarLinks.outlook}
+              className="text-primary underline"
+            >
+              Outlook
+            </Link>
+          </Text>
+          <Text className="text-muted-foreground m-0 mt-1 text-[12px] leading-5">
+            Apple Calendar users: open the attached invite (.ics).
+          </Text>
+        </>
+      ) : null}
     </Section>
     <Text className="text-foreground m-0 mb-3 text-center text-[15px] leading-6">
       If asked, present this QR code at the event:
@@ -78,6 +105,10 @@ RsvpConfirmationEmail.PreviewProps = {
   meetupName: 'Tex Mechs Spring Meetup',
   meetupDate: 'Saturday, April 12, 2026 at 1:00 PM',
   meetupLocation: 'Austin Convention Center, Austin, TX',
+  calendarLinks: {
+    google: 'https://calendar.google.com/calendar/render?action=TEMPLATE',
+    outlook: 'https://outlook.live.com/calendar/0/action/compose',
+  },
 } satisfies RsvpConfirmationEmailProps;
 
 export default RsvpConfirmationEmail;

--- a/frontend/src/components/Meetups/AddToCalendarButton.tsx
+++ b/frontend/src/components/Meetups/AddToCalendarButton.tsx
@@ -1,0 +1,66 @@
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import config from '@/config';
+import { buildMeetupCalendarLinks, type MeetupInfo } from '@keebmeet/shared';
+import { type ReactNode } from 'react';
+import { FiCalendar } from 'react-icons/fi';
+
+interface AddToCalendarButtonProps {
+  meetup: MeetupInfo;
+}
+
+export const AddToCalendarButton = ({
+  meetup,
+}: AddToCalendarButtonProps): ReactNode => {
+  const links = buildMeetupCalendarLinks({
+    id: meetup.id,
+    title: meetup.name,
+    description: meetup.description,
+    location:
+      meetup.location.full_address ??
+      [meetup.location.city, meetup.location.state, meetup.location.country]
+        .filter((part) => part != null && part !== '')
+        .join(', '),
+    // date carries its UTC offset, so it's the correct absolute instant.
+    start: meetup.date,
+    durationHours: meetup.duration_hours ?? 0,
+  });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          title="Add to calendar"
+          aria-label="Add to calendar"
+        >
+          <FiCalendar />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem asChild>
+          <a href={links.google} target="_blank" rel="noopener noreferrer">
+            Google Calendar
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <a href={links.outlook} target="_blank" rel="noopener noreferrer">
+            Outlook
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          {/* An endpoint, not a data: URI, so mobile opens the calendar app. */}
+          <a href={`${config.apiUrl}/meetups/${meetup.slug}/calendar.ics`}>
+            Apple / other (.ics)
+          </a>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/frontend/src/components/Meetups/MeetupModal.tsx
+++ b/frontend/src/components/Meetups/MeetupModal.tsx
@@ -40,6 +40,7 @@ import { hasMeetupEnded, isMeetupHappeningNow } from '../../util/timeUtil';
 import { CopyButton } from '../CopyButton';
 import { isNotFoundError } from '../Guards/Guards';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { AddToCalendarButton } from './AddToCalendarButton';
 import { HoldCountdown } from './HoldCountdown';
 import { MeetupCapacityStatus } from './MeetupCapacityStatus';
 import { UNLISTED_REASON_TEXT } from './MeetupCard';
@@ -453,6 +454,9 @@ export const MeetupModal = ({
                   toastMessage="Link copied to clipboard"
                   className="ml-auto"
                 />
+                {!hasEnded && !meetup.is_archive ? (
+                  <AddToCalendarButton meetup={meetup} />
+                ) : null}
                 {isUserOrganizer && (
                   <Button
                     variant="outline"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7887,6 +7887,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/calendar-link": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/calendar-link/-/calendar-link-2.11.4.tgz",
+      "integrity": "sha512-K+wvjZs8olNSDPwY7pKPa9d65nQpTkfmWbYIfRGrGNPaht2ox6sPUTwdUuoodc7c31S2rUegA3yY9bXqVcevXw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.20"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -21143,6 +21152,7 @@
       "name": "@keebmeet/shared",
       "version": "0.0.0",
       "dependencies": {
+        "calendar-link": "^2.11.4",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -9,6 +9,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "calendar-link": "^2.11.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/shared/src/calendar.ts
+++ b/shared/src/calendar.ts
@@ -1,0 +1,43 @@
+import { google, ics, outlook } from 'calendar-link';
+
+export interface MeetupCalendarEvent {
+  id: string;
+  title: string;
+  description?: string;
+  location: string;
+  // Absolute start instant; an ISO string must carry its UTC offset.
+  start: Date | string;
+  durationHours: number;
+}
+
+export interface MeetupCalendarLinks {
+  google: string;
+  outlook: string;
+}
+
+const toCalendarEvent = (event: MeetupCalendarEvent) => ({
+  title: event.title,
+  description: event.description,
+  location: event.location,
+  duration: [event.durationHours, 'hour'] as [number, 'hour'],
+  start: event.start,
+  // Stable UID so a re-sent invite updates the same event.
+  uid: `keebmeet-meetup-${event.id}`,
+});
+
+export const buildMeetupCalendarLinks = (
+  event: MeetupCalendarEvent
+): MeetupCalendarLinks => {
+  const calendarEvent = toCalendarEvent(event);
+  return {
+    google: google(calendarEvent),
+    outlook: outlook(calendarEvent),
+  };
+};
+
+// Raw .ics text, decoded from calendar-link's data URI so it can be attached to
+// an email (many clients strip data: links).
+export const buildMeetupIcsContent = (event: MeetupCalendarEvent): string => {
+  const dataUri = ics(toCalendarEvent(event));
+  return decodeURIComponent(dataUri.slice(dataUri.indexOf(',') + 1));
+};

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 // Public surface of @keebmeet/shared — the API contract shared by the backend
 // (which produces it) and the frontend (which consumes it).
+export * from './calendar';
 export * from './dto';
 export * from './validation';
 export * from './eventbriteInterfaces';


### PR DESCRIPTION
Add a shared calendar-link helper and surface it in two places:
- RSVP modal: a ghost calendar icon button with a Google/Outlook/.ics dropdown; the .ics option hits a new GET /meetups/:slug/calendar.ics endpoint so mobile hands it straight to the calendar app.
- RSVP confirmation email: Google/Outlook links in the details card plus the raw .ics attached for clients that strip data: links.