### PR TITLE
Feature/improve modal layout

### DIFF
--- a/frontend/src/components/Meetups/AddToCalendarSubMenu.tsx
+++ b/frontend/src/components/Meetups/AddToCalendarSubMenu.tsx
@@ -1,22 +1,21 @@
-import { Button } from '@/components/ui/button';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu';
 import config from '@/config';
 import { buildMeetupCalendarLinks, type MeetupInfo } from '@keebmeet/shared';
 import { type ReactNode } from 'react';
 import { FiCalendar } from 'react-icons/fi';
 
-interface AddToCalendarButtonProps {
+interface AddToCalendarSubMenuProps {
   meetup: MeetupInfo;
 }
 
-export const AddToCalendarButton = ({
+export const AddToCalendarSubMenu = ({
   meetup,
-}: AddToCalendarButtonProps): ReactNode => {
+}: AddToCalendarSubMenuProps): ReactNode => {
   const links = buildMeetupCalendarLinks({
     id: meetup.id,
     title: meetup.name,
@@ -32,18 +31,12 @@ export const AddToCalendarButton = ({
   });
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          title="Add to calendar"
-          aria-label="Add to calendar"
-        >
-          <FiCalendar />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger className="gap-2">
+        <FiCalendar />
+        Add to calendar
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent>
         <DropdownMenuItem asChild>
           <a href={links.google} target="_blank" rel="noopener noreferrer">
             Google Calendar
@@ -60,7 +53,7 @@ export const AddToCalendarButton = ({
             Apple / other (.ics)
           </a>
         </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   );
 };

--- a/frontend/src/components/Meetups/MeetupModal.tsx
+++ b/frontend/src/components/Meetups/MeetupModal.tsx
@@ -448,7 +448,7 @@ export const MeetupModal = ({
               ) : (
                 <span />
               )}
-              <div className="ml-auto flex flex-wrap items-center gap-3">
+              <div className="ml-auto flex flex-wrap items-center justify-end gap-3">
                 <CopyButton
                   value={`${window.location.origin}/meetup/${meetupId}`}
                   icon={FiLink}

--- a/frontend/src/components/Meetups/MeetupModal.tsx
+++ b/frontend/src/components/Meetups/MeetupModal.tsx
@@ -10,6 +10,12 @@ import {
   DialogOverlay,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { ImageWithFallback } from '@/components/ui/image-with-fallback';
 import { useSwipeToDismiss } from '@/hooks/useSwipeToDismiss';
 import { cn } from '@/lib/utils';
@@ -26,22 +32,23 @@ import {
   FiLink,
   FiMap,
   FiMapPin,
+  FiMoreHorizontal,
   FiTag,
   FiUser,
   FiUserCheck,
   FiX,
 } from 'react-icons/fi';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import { useHoldCountdown } from '../../hooks/useHoldCountdown';
 import { socket } from '../../socket';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { meetupSlice, useGetMeetupQuery } from '../../store/meetupSlice';
 import { formatMoney } from '../../util/money';
 import { hasMeetupEnded, isMeetupHappeningNow } from '../../util/timeUtil';
-import { CopyButton } from '../CopyButton';
 import { isNotFoundError } from '../Guards/Guards';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import { AddToCalendarButton } from './AddToCalendarButton';
+import { AddToCalendarSubMenu } from './AddToCalendarSubMenu';
 import { HoldCountdown } from './HoldCountdown';
 import { MeetupCapacityStatus } from './MeetupCapacityStatus';
 import { UNLISTED_REASON_TEXT } from './MeetupCard';
@@ -189,6 +196,7 @@ export const MeetupModal = ({
   const hasPendingHold = effectiveTicket?.payment_status === 'pending';
   const isConfirmedAttendee = effectiveTicket != null && !hasPendingHold;
   const showRsvpAction = !isRsvp && isRsvpable;
+  const showCalendarAction = !hasEnded && !meetup.is_archive;
 
   const linkedOrganizers =
     meetup.organizers != null
@@ -449,32 +457,49 @@ export const MeetupModal = ({
                 <span />
               )}
               <div className="ml-auto flex flex-wrap items-center justify-end gap-3">
-                <CopyButton
-                  value={`${window.location.origin}/meetup/${meetupId}`}
-                  icon={FiLink}
-                  label="Copy link"
-                  toastMessage="Link copied to clipboard"
-                  className="ml-auto"
-                />
-                {!hasEnded && !meetup.is_archive ? (
-                  <AddToCalendarButton meetup={meetup} />
-                ) : null}
-                {!onMapPage ? (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    title="View on map"
-                    aria-label="View on map"
-                    onClick={() => {
-                      onClose();
-                      void navigate('/map', {
-                        state: { focusSlug: meetup.slug },
-                      });
-                    }}
-                  >
-                    <FiMap />
-                  </Button>
-                ) : null}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="More actions"
+                      aria-label="More actions"
+                    >
+                      <FiMoreHorizontal />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="gap-2"
+                      onClick={() => {
+                        void navigator.clipboard.writeText(
+                          `${window.location.origin}/meetup/${meetupId}`
+                        );
+                        toast.success('Link copied to clipboard');
+                      }}
+                    >
+                      <FiLink />
+                      Copy link
+                    </DropdownMenuItem>
+                    {showCalendarAction ? (
+                      <AddToCalendarSubMenu meetup={meetup} />
+                    ) : null}
+                    {!onMapPage ? (
+                      <DropdownMenuItem
+                        className="gap-2"
+                        onClick={() => {
+                          onClose();
+                          void navigate('/map', {
+                            state: { focusSlug: meetup.slug },
+                          });
+                        }}
+                      >
+                        <FiMap />
+                        View on map
+                      </DropdownMenuItem>
+                    ) : null}
+                  </DropdownMenuContent>
+                </DropdownMenu>
                 {isUserOrganizer && (
                   <Button
                     variant="outline"

--- a/frontend/src/components/Meetups/MeetupModal.tsx
+++ b/frontend/src/components/Meetups/MeetupModal.tsx
@@ -23,7 +23,7 @@ import { type SimpleTicketInfo } from '@keebmeet/shared';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { AnimatePresence, motion } from 'framer-motion';
-import { ArchiveIcon, EyeOffIcon, Settings } from 'lucide-react';
+import { ArchiveIcon, EyeOffIcon, Settings, Ticket } from 'lucide-react';
 import { useEffect, useState, type ReactNode } from 'react';
 import {
   FiCalendar,
@@ -201,8 +201,7 @@ export const MeetupModal = ({
     isHappeningNow ||
     hasEnded ||
     meetup.is_archive ||
-    meetup.is_unlisted === true ||
-    (meetup.tags?.length ?? 0) > 0;
+    meetup.is_unlisted === true;
 
   const linkedOrganizers =
     meetup.organizers != null
@@ -298,54 +297,10 @@ export const MeetupModal = ({
               ) : null}
               <div className="flex flex-col p-4 pb-0">
                 <DialogHeader className="space-y-0 text-left">
-                  {showBadges ? (
-                    <div className="flex flex-wrap items-center gap-2 pb-2">
-                      {isHappeningNow ? (
-                        <Badge className="bg-green-600 text-white">
-                          <span className="size-1.5 animate-pulse rounded-full bg-white" />
-                          Happening now
-                        </Badge>
-                      ) : hasEnded ? (
-                        <Badge variant="secondary">Ended</Badge>
-                      ) : null}
-                      {meetup.is_archive ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Badge variant="secondary">
-                              <ArchiveIcon className="size-3.5" />
-                              Archived
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            This is an archived meetup
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : null}
-                      {meetup.is_unlisted === true ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Badge variant="secondary">
-                              <EyeOffIcon className="size-3.5" />
-                              Unlisted
-                            </Badge>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            This meetup is unlisted
-                            {meetup.unlisted_reason != null
-                              ? `. You can see it because ${UNLISTED_REASON_TEXT[meetup.unlisted_reason]}.`
-                              : ''}
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : null}
-                      {meetup.tags?.map((tag) => (
-                        <TagBadge key={tag.id} tag={tag} />
-                      ))}
-                    </div>
-                  ) : null}
                   <div
                     className={cn(
-                      'flex items-start justify-between gap-2 pb-2',
-                      !hasImage && !showBadges && 'pr-8'
+                      'flex items-start justify-between gap-2',
+                      !hasImage && 'pr-8'
                     )}
                   >
                     <DialogTitle className="min-w-0 text-2xl font-bold">
@@ -396,11 +351,52 @@ export const MeetupModal = ({
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </div>
+                  {showBadges ? (
+                    <div className="flex flex-wrap items-center gap-2 pb-2">
+                      {isHappeningNow ? (
+                        <Badge className="bg-green-600 text-white">
+                          <span className="size-1.5 animate-pulse rounded-full bg-white" />
+                          Happening now
+                        </Badge>
+                      ) : hasEnded ? (
+                        <Badge variant="secondary">Ended</Badge>
+                      ) : null}
+                      {meetup.is_archive ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant="secondary">
+                              <ArchiveIcon className="size-3.5" />
+                              Archived
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            This is an archived meetup
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : null}
+                      {meetup.is_unlisted === true ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge variant="secondary">
+                              <EyeOffIcon className="size-3.5" />
+                              Unlisted
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            This meetup is unlisted
+                            {meetup.unlisted_reason != null
+                              ? `. You can see it because ${UNLISTED_REASON_TEXT[meetup.unlisted_reason]}.`
+                              : ''}
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </DialogHeader>
                 <div className="flex flex-col gap-1 pb-4 font-semibold">
                   {paidTicketType != null ? (
                     <div className="flex items-start gap-2">
-                      <FiTag className="mt-1 shrink-0" />
+                      <Ticket className="mt-1 size-4 shrink-0" />
                       <p>
                         {formatMoney(
                           paidTicketType.price_cents,
@@ -465,6 +461,18 @@ export const MeetupModal = ({
                     <div className="flex items-start gap-2">
                       <FiUser className="mt-1 shrink-0" />
                       <p>Organized by {organizerNodes}</p>
+                    </div>
+                  ) : null}
+
+                  {/* Tags */}
+                  {(meetup.tags?.length ?? 0) > 0 ? (
+                    <div className="flex items-start gap-2">
+                      <FiTag className="mt-1 shrink-0" />
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {meetup.tags?.map((tag) => (
+                          <TagBadge key={tag.id} tag={tag} />
+                        ))}
+                      </div>
                     </div>
                   ) : null}
                 </div>

--- a/frontend/src/components/Meetups/MeetupModal.tsx
+++ b/frontend/src/components/Meetups/MeetupModal.tsx
@@ -197,6 +197,12 @@ export const MeetupModal = ({
   const isConfirmedAttendee = effectiveTicket != null && !hasPendingHold;
   const showRsvpAction = !isRsvp && isRsvpable;
   const showCalendarAction = !hasEnded && !meetup.is_archive;
+  const showBadges =
+    isHappeningNow ||
+    hasEnded ||
+    meetup.is_archive ||
+    meetup.is_unlisted === true ||
+    (meetup.tags?.length ?? 0) > 0;
 
   const linkedOrganizers =
     meetup.organizers != null
@@ -292,11 +298,7 @@ export const MeetupModal = ({
               ) : null}
               <div className="flex flex-col p-4 pb-0">
                 <DialogHeader className="space-y-0 text-left">
-                  {isHappeningNow ||
-                  hasEnded ||
-                  meetup.is_archive ||
-                  meetup.is_unlisted === true ||
-                  (meetup.tags?.length ?? 0) > 0 ? (
+                  {showBadges ? (
                     <div className="flex flex-wrap items-center gap-2 pb-2">
                       {isHappeningNow ? (
                         <Badge className="bg-green-600 text-white">
@@ -340,9 +342,60 @@ export const MeetupModal = ({
                       ))}
                     </div>
                   ) : null}
-                  <DialogTitle className="pb-2 text-2xl font-bold">
-                    {meetup.name}
-                  </DialogTitle>
+                  <div
+                    className={cn(
+                      'flex items-start justify-between gap-2 pb-2',
+                      !hasImage && !showBadges && 'pr-8'
+                    )}
+                  >
+                    <DialogTitle className="min-w-0 text-2xl font-bold">
+                      {meetup.name}
+                    </DialogTitle>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="More actions"
+                          aria-label="More actions"
+                          className="-mt-1 shrink-0"
+                        >
+                          <FiMoreHorizontal />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          className="gap-2"
+                          onClick={() => {
+                            void navigator.clipboard.writeText(
+                              `${window.location.origin}/meetup/${meetupId}`
+                            );
+                            toast.success('Link copied to clipboard');
+                          }}
+                        >
+                          <FiLink />
+                          Copy link
+                        </DropdownMenuItem>
+                        {showCalendarAction ? (
+                          <AddToCalendarSubMenu meetup={meetup} />
+                        ) : null}
+                        {!onMapPage ? (
+                          <DropdownMenuItem
+                            className="gap-2"
+                            onClick={() => {
+                              onClose();
+                              void navigate('/map', {
+                                state: { focusSlug: meetup.slug },
+                              });
+                            }}
+                          >
+                            <FiMap />
+                            View on map
+                          </DropdownMenuItem>
+                        ) : null}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
                 </DialogHeader>
                 <div className="flex flex-col gap-1 pb-4 font-semibold">
                   {paidTicketType != null ? (
@@ -457,49 +510,6 @@ export const MeetupModal = ({
                 <span />
               )}
               <div className="ml-auto flex flex-wrap items-center justify-end gap-3">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      title="More actions"
-                      aria-label="More actions"
-                    >
-                      <FiMoreHorizontal />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      className="gap-2"
-                      onClick={() => {
-                        void navigator.clipboard.writeText(
-                          `${window.location.origin}/meetup/${meetupId}`
-                        );
-                        toast.success('Link copied to clipboard');
-                      }}
-                    >
-                      <FiLink />
-                      Copy link
-                    </DropdownMenuItem>
-                    {showCalendarAction ? (
-                      <AddToCalendarSubMenu meetup={meetup} />
-                    ) : null}
-                    {!onMapPage ? (
-                      <DropdownMenuItem
-                        className="gap-2"
-                        onClick={() => {
-                          onClose();
-                          void navigate('/map', {
-                            state: { focusSlug: meetup.slug },
-                          });
-                        }}
-                      >
-                        <FiMap />
-                        View on map
-                      </DropdownMenuItem>
-                    ) : null}
-                  </DropdownMenuContent>
-                </DropdownMenu>
                 {isUserOrganizer && (
                   <Button
                     variant="outline"


### PR DESCRIPTION
Since we have so many buttons now, they get collapsed into a menu (3 dots). That menu is on the top right of the modal, next to the title. It looked pretty bad with the badges, so the status badges were moved below the title and tags moved into their own line item.