### PR TITLE
Fix blank page on insecure origins from crypto.randomUUID

### DIFF
--- a/frontend/src/components/Meetups/AddressCombobox.tsx
+++ b/frontend/src/components/Meetups/AddressCombobox.tsx
@@ -6,6 +6,7 @@ import {
   ComboboxItem,
   ComboboxList,
 } from '@/components/ui/combobox';
+import { randomUUID } from '@/lib/utils';
 import { type PlaceSuggestionInfo } from '@keebmeet/shared';
 import { useEffect, useState, type ReactNode } from 'react';
 import {
@@ -39,7 +40,7 @@ const AddressCombobox = ({
 }: Props): ReactNode => {
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
-  const [session, setSession] = useState(() => crypto.randomUUID());
+  const [session, setSession] = useState(() => randomUUID());
   const [fetchPlaceDetails] = useLazyPlaceDetailsQuery();
 
   useEffect(() => {
@@ -86,7 +87,7 @@ const AddressCombobox = ({
       onPlaceSelect(suggestion.resolved);
       return;
     }
-    setSession(crypto.randomUUID());
+    setSession(randomUUID());
     const details = await fetchPlaceDetails({
       placeId: suggestion.place_id,
       session,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -11,3 +11,18 @@ export function isTouchDevice(): boolean {
     window.matchMedia('(pointer: coarse)').matches
   );
 }
+
+/**
+ * crypto.randomUUID exists only in secure contexts, so plain-HTTP LAN dev
+ * (e.g. testing from a phone) needs the getRandomValues-based fallback.
+ */
+export function randomUUID(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+    ''
+  );
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
crypto.randomUUID only exists in secure contexts, so the address combobox crashed the whole page in plain-HTTP LAN dev (e.g. phone testing). Fall back to a getRandomValues-based UUIDv4.